### PR TITLE
Adds FREQM Peripheral Usage, and FrequencyIn Usage to TC functions

### DIFF
--- a/samd/clocks.h
+++ b/samd/clocks.h
@@ -71,5 +71,10 @@ uint32_t clock_get_frequency(uint8_t type, uint8_t index);
 uint32_t clock_get_calibration(uint8_t type, uint8_t index);
 int clock_set_calibration(uint8_t type, uint8_t index, uint32_t val);
 void save_usb_clock_calibration(void);
+#ifdef SAMD51
+void freqm_init(uint8_t ref_clock, uint8_t msr_clock, uint8_t cycles);
+uint32_t freqm_read(void);
+void freqm_deinit(void);
+#endif
 
 #endif  // MICROPY_INCLUDED_ATMEL_SAMD_CLOCKS_H

--- a/samd/clocks.h
+++ b/samd/clocks.h
@@ -72,7 +72,7 @@ uint32_t clock_get_calibration(uint8_t type, uint8_t index);
 int clock_set_calibration(uint8_t type, uint8_t index, uint32_t val);
 void save_usb_clock_calibration(void);
 #ifdef SAMD51
-void freqm_init(uint8_t ref_clock, uint8_t msr_clock, uint8_t cycles);
+void freqm_init(uint8_t msr_clock, uint8_t cycles);
 uint32_t freqm_read(void);
 void freqm_deinit(void);
 #endif

--- a/samd/samd21/timers.c
+++ b/samd/samd21/timers.c
@@ -29,7 +29,7 @@
 
 #include "samd/timers.h"
 
-//#include "common-hal/pulseio/PulseOut.h"
+#include "timer_handler.h"
 
 #include "hpl/gclk/hpl_gclk_base.h"
 
@@ -46,7 +46,7 @@ const uint8_t tc_gclk_ids[TC_INST_NUM] = {TC3_GCLK_ID,
             };
 const uint8_t tcc_gclk_ids[3] = {TCC0_GCLK_ID, TCC1_GCLK_ID, TCC2_GCLK_ID};
 
-void turn_on_clocks(bool is_tc, uint8_t index, uint32_t gclk_index) {
+void turn_on_clocks(bool is_tc, uint8_t index, uint32_t gclk_index, uint8_t timer_handler) {
     uint8_t gclk_id;
     if (is_tc) {
         gclk_id = tc_gclk_ids[index];
@@ -61,6 +61,7 @@ void turn_on_clocks(bool is_tc, uint8_t index, uint32_t gclk_index) {
     }
     PM->APBCMASK.reg |= 1 << clock_slot;
     _gclk_enable_channel(gclk_id, gclk_index);
+    set_timer_handler(index, timer_handler);
 }
 
 void tc_set_enable(Tc* tc, bool enable) {

--- a/samd/samd51/timers.c
+++ b/samd/samd51/timers.c
@@ -29,6 +29,8 @@
 
 #include "samd/timers.h"
 
+#include "timer_handler.h"
+
 #include "hri/hri_gclk_d51.h"
 
 const uint8_t tcc_cc_num[5] = {6, 4, 3, 2, 2};
@@ -60,7 +62,7 @@ const uint8_t tcc_gclk_ids[TCC_INST_NUM] = {TCC0_GCLK_ID,
 #endif
                                     };
 
-void turn_on_clocks(bool is_tc, uint8_t index, uint32_t gclk_index) {
+void turn_on_clocks(bool is_tc, uint8_t index, uint32_t gclk_index, uint8_t timer_handler) {
     uint8_t gclk_id;
     if (is_tc) {
         gclk_id = tc_gclk_ids[index];
@@ -69,6 +71,7 @@ void turn_on_clocks(bool is_tc, uint8_t index, uint32_t gclk_index) {
     }
     // Turn on the clocks for the peripherals.
     if (is_tc) {
+        set_timer_handler(index, timer_handler);
         switch (index) {
             case 0:
                 MCLK->APBAMASK.reg |= MCLK_APBAMASK_TC0;

--- a/samd/timers.c
+++ b/samd/timers.c
@@ -29,9 +29,6 @@
 
 #include "timers.h"
 
-#include "common-hal/pulseio/PulseOut.h"
-#include "common-hal/pulseio/FrequencyIn.h"
-
 const uint16_t prescaler[8] = {1, 2, 4, 8, 16, 64, 256, 1024};
 
 Tc* const tc_insts[TC_INST_NUM] = TC_INSTS;
@@ -88,18 +85,6 @@ void tc_reset(Tc* tc) {
     }
 }
 
-void shared_timer_handler(bool is_tc, uint8_t index, bool pulseout) {
-    // Add calls to interrupt handlers for specific functionality here.
-    if (is_tc) {
-        if (pulseout) {
-            pulseout_interrupt_handler(index);
-            } else {
-            frequencyin_interrupt_handler(index);
-        }
-    }
-}
-
-
 #ifdef SAMD51
 #define TC_OFFSET 0
 #endif
@@ -108,126 +93,46 @@ void shared_timer_handler(bool is_tc, uint8_t index, bool pulseout) {
 #endif
 
 void TCC0_Handler(void) {
-    shared_timer_handler(false, 0, false);
+    shared_timer_handler(false, 0);
 }
 void TCC1_Handler(void) {
-    shared_timer_handler(false, 1, false);
+    shared_timer_handler(false, 1);
 }
 void TCC2_Handler(void) {
-    shared_timer_handler(false, 2, false);
+    shared_timer_handler(false, 2);
 }
 // TC0 - TC2 only exist on the SAMD51
 #ifdef TC0
 void TC0_Handler(void) {
-    if (TC0->COUNT16.EVCTRL.bit.TCEI == 1 &&
-#ifdef SAMD21
-    TC0->COUNT16.CTRLC.bit.CPTEN0 == 1) {
-#endif
-#ifdef SAMD51
-    TC0->COUNT16.CTRLA.bit.CAPTEN0 == 1) {
-#endif
-        shared_timer_handler(true, 0, false);
-    } else {
-        shared_timer_handler(true, 0, true);
-    }
+    shared_timer_handler(true, 0);
 }
 #endif
 #ifdef TC1
 void TC1_Handler(void) {
-    if (TC1->COUNT16.EVCTRL.bit.TCEI == 1 &&
-#ifdef SAMD21
-    TC1->COUNT16.CTRLC.bit.CPTEN0 == 1) {
-#endif
-#ifdef SAMD51
-    TC1->COUNT16.CTRLA.bit.CAPTEN0 == 1) {
-#endif
-        shared_timer_handler(true, 1, false);
-    } else {
-        shared_timer_handler(true, 1, true);
-    }
+    shared_timer_handler(true, 1);
 }
 #endif
 #ifdef TC2
 void TC2_Handler(void) {
-    if (TC2->COUNT16.EVCTRL.bit.TCEI == 1 &&
-#ifdef SAMD21
-    TC2->COUNT16.CTRLC.bit.CPTEN0 == 1) {
-#endif
-#ifdef SAMD51
-    TC2->COUNT16.CTRLA.bit.CAPTEN0 == 1) {
-#endif
-        shared_timer_handler(true, 2, false);
-    } else {
-        shared_timer_handler(true, 2, true);
-    }
+    shared_timer_handler(true, 2);
 }
 #endif
 void TC3_Handler(void) {
-    if (TC3->COUNT16.EVCTRL.bit.TCEI == 1 &&
-#ifdef SAMD21
-    TC3->COUNT16.CTRLC.bit.CPTEN0 == 1) {
-#endif
-#ifdef SAMD51
-    TC3->COUNT16.CTRLA.bit.CAPTEN0 == 1) {
-#endif
-        shared_timer_handler(true, 3 - TC_OFFSET, false);
-    } else {
-        shared_timer_handler(true, 3 - TC_OFFSET, true);
-    }
+    shared_timer_handler(true, 3 - TC_OFFSET);
 }
 void TC4_Handler(void) {
-    if (TC4->COUNT16.EVCTRL.bit.TCEI == 1 &&
-#ifdef SAMD21
-    TC4->COUNT16.CTRLC.bit.CPTEN0 == 1) {
-#endif
-#ifdef SAMD51
-    TC4->COUNT16.CTRLA.bit.CAPTEN0 == 1) {
-#endif
-        shared_timer_handler(true, 4 - TC_OFFSET, false);
-    } else {
-        shared_timer_handler(true, 4 - TC_OFFSET, true);
-    }
+    shared_timer_handler(true, 4 - TC_OFFSET);
 }
 void TC5_Handler(void) {
-    if (TC5->COUNT16.EVCTRL.bit.TCEI == 1 &&
-#ifdef SAMD21
-    TC5->COUNT16.CTRLC.bit.CPTEN0 == 1) {
-#endif
-#ifdef SAMD51
-    TC5->COUNT16.CTRLA.bit.CAPTEN0 == 1) {
-#endif
-        shared_timer_handler(true, 5 - TC_OFFSET, false);
-    } else {
-        shared_timer_handler(true, 5 - TC_OFFSET, true);
-    }
+    shared_timer_handler(true, 5 - TC_OFFSET);
 }
 #ifdef TC6
 void TC6_Handler(void) {
-    if (TC6->COUNT16.EVCTRL.bit.TCEI == 1 &&
-#ifdef SAMD21
-    TC6->COUNT16.CTRLC.bit.CPTEN0 == 1) {
-#endif
-#ifdef SAMD51
-    TC6->COUNT16.CTRLA.bit.CAPTEN0 == 1) {
-#endif
-        shared_timer_handler(true, 6 - TC_OFFSET, false);
-    } else {
-        shared_timer_handler(true, 6 - TC_OFFSET, true);
-    }
+    shared_timer_handler(true, 6 - TC_OFFSET);
 }
 #endif
 #ifdef TC7
 void TC7_Handler(void) {
-    if (TC7->COUNT16.EVCTRL.bit.TCEI == 1 &&
-#ifdef SAMD21
-    TC7->COUNT16.CTRLC.bit.CPTEN0 == 1) {
-#endif
-#ifdef SAMD51
-    TC7->COUNT16.CTRLA.bit.CAPTEN0 == 1) {
-#endif
-        shared_timer_handler(true, 7 - TC_OFFSET, false);
-    } else {
-        shared_timer_handler(true, 7 - TC_OFFSET, true);
-    }
+    shared_timer_handler(true, 7 - TC_OFFSET);
 }
 #endif

--- a/samd/timers.c
+++ b/samd/timers.c
@@ -30,6 +30,7 @@
 #include "timers.h"
 
 #include "common-hal/pulseio/PulseOut.h"
+#include "common-hal/pulseio/FrequencyIn.h"
 
 const uint16_t prescaler[8] = {1, 2, 4, 8, 16, 64, 256, 1024};
 
@@ -87,12 +88,17 @@ void tc_reset(Tc* tc) {
     }
 }
 
-void shared_timer_handler(bool is_tc, uint8_t index) {
+void shared_timer_handler(bool is_tc, uint8_t index, bool pulseout) {
     // Add calls to interrupt handlers for specific functionality here.
     if (is_tc) {
-        pulseout_interrupt_handler(index);
+        if (pulseout) {
+            pulseout_interrupt_handler(index);
+            } else {
+            frequencyin_interrupt_handler(index);
+        }
     }
 }
+
 
 #ifdef SAMD51
 #define TC_OFFSET 0
@@ -113,35 +119,75 @@ void TCC2_Handler(void) {
 // TC0 - TC2 only exist on the SAMD51
 #ifdef TC0
 void TC0_Handler(void) {
-    shared_timer_handler(true, 0);
+    if (TC0->COUNT16.EVCTRL.bit.TCEI == 1 &&
+    (TC0->COUNT16.CTRLC.bit.CPTEN0 == 1 || TC0->COUNT16.CTRLC.bit.CPTEN1 == 1)) {
+        shared_timer_handler(true, 0, false);
+        } else {
+        shared_timer_handler(true, 0, true);
+    }
 }
 #endif
 #ifdef TC1
 void TC1_Handler(void) {
-    shared_timer_handler(true, 1);
+    if (TC1->COUNT16.EVCTRL.bit.TCEI == 1 &&
+    (TC1->COUNT16.CTRLC.bit.CPTEN0 == 1 || TC1->COUNT16.CTRLC.bit.CPTEN1 == 1)) {
+        shared_timer_handler(true, 1, false);
+        } else {
+        shared_timer_handler(true, 1, true);
+    }
 }
 #endif
 #ifdef TC2
 void TC2_Handler(void) {
-    shared_timer_handler(true, 2);
+    if (TC2->COUNT16.EVCTRL.bit.TCEI == 1 &&
+    (TC2->COUNT16.CTRLC.bit.CPTEN0 == 1 || TC2->COUNT16.CTRLC.bit.CPTEN1 == 1)) {
+        shared_timer_handler(true, 2, false);
+        } else {
+        shared_timer_handler(true, 2, true);
+    }
 }
 #endif
 void TC3_Handler(void) {
-    shared_timer_handler(true, 3 - TC_OFFSET);
+    if (TC3->COUNT16.EVCTRL.bit.TCEI == 1 &&
+    (TC3->COUNT16.CTRLC.bit.CPTEN0 == 1 || TC3->COUNT16.CTRLC.bit.CPTEN1 == 1)) {
+        shared_timer_handler(true, 3 - TC_OFFSET, false);
+        } else {
+        shared_timer_handler(true, 3 - TC_OFFSET, true);
+    }
 }
 void TC4_Handler(void) {
-    shared_timer_handler(true, 4 - TC_OFFSET);
+    if (TC4->COUNT16.EVCTRL.bit.TCEI == 1 &&
+    (TC4->COUNT16.CTRLC.bit.CPTEN0 == 1 || TC4->COUNT16.CTRLC.bit.CPTEN1 == 1)) {
+        shared_timer_handler(true, 4 - TC_OFFSET, false);
+        } else {
+        shared_timer_handler(true, 4 - TC_OFFSET, true);
+    }
 }
 void TC5_Handler(void) {
-    shared_timer_handler(true, 5 - TC_OFFSET);
+    if (TC5->COUNT16.EVCTRL.bit.TCEI == 1 &&
+    (TC5->COUNT16.CTRLC.bit.CPTEN0 == 1 || TC5->COUNT16.CTRLC.bit.CPTEN1 == 1)) {
+        shared_timer_handler(true, 5 - TC_OFFSET, false);
+        } else {
+        shared_timer_handler(true, 5 - TC_OFFSET, true);
+    }
 }
 #ifdef TC6
 void TC6_Handler(void) {
-    shared_timer_handler(true, 6 - TC_OFFSET);
+    if (TC6->COUNT16.EVCTRL.bit.TCEI == 1 &&
+    (TC6->COUNT16.CTRLC.bit.CPTEN0 == 1 || TC6->COUNT16.CTRLC.bit.CPTEN1 == 1)) {
+        shared_timer_handler(true, 6 - TC_OFFSET, false);
+        } else {
+        shared_timer_handler(true, 6 - TC_OFFSET, true);
+    }
 }
 #endif
 #ifdef TC7
 void TC7_Handler(void) {
-    shared_timer_handler(true, 7 - TC_OFFSET);
+    if (TC7->COUNT16.EVCTRL.bit.TCEI == 1 &&
+    (TC7->COUNT16.CTRLC.bit.CPTEN0 == 1 || TC7->COUNT16.CTRLC.bit.CPTEN1 == 1)) {
+        shared_timer_handler(true, 7 - TC_OFFSET, false);
+        } else {
+        shared_timer_handler(true, 7 - TC_OFFSET, true);
+    }
 }
 #endif

--- a/samd/timers.c
+++ b/samd/timers.c
@@ -108,21 +108,26 @@ void shared_timer_handler(bool is_tc, uint8_t index, bool pulseout) {
 #endif
 
 void TCC0_Handler(void) {
-    shared_timer_handler(false, 0);
+    shared_timer_handler(false, 0, false);
 }
 void TCC1_Handler(void) {
-    shared_timer_handler(false, 1);
+    shared_timer_handler(false, 1, false);
 }
 void TCC2_Handler(void) {
-    shared_timer_handler(false, 2);
+    shared_timer_handler(false, 2, false);
 }
 // TC0 - TC2 only exist on the SAMD51
 #ifdef TC0
 void TC0_Handler(void) {
     if (TC0->COUNT16.EVCTRL.bit.TCEI == 1 &&
-    (TC0->COUNT16.CTRLC.bit.CPTEN0 == 1 || TC0->COUNT16.CTRLC.bit.CPTEN1 == 1)) {
+#ifdef SAMD21
+    TC0->COUNT16.CTRLC.bit.CPTEN0 == 1) {
+#endif
+#ifdef SAMD51
+    TC0->COUNT16.CTRLA.bit.CAPTEN0 == 1) {
+#endif
         shared_timer_handler(true, 0, false);
-        } else {
+    } else {
         shared_timer_handler(true, 0, true);
     }
 }
@@ -130,9 +135,14 @@ void TC0_Handler(void) {
 #ifdef TC1
 void TC1_Handler(void) {
     if (TC1->COUNT16.EVCTRL.bit.TCEI == 1 &&
-    (TC1->COUNT16.CTRLC.bit.CPTEN0 == 1 || TC1->COUNT16.CTRLC.bit.CPTEN1 == 1)) {
+#ifdef SAMD21
+    TC1->COUNT16.CTRLC.bit.CPTEN0 == 1) {
+#endif
+#ifdef SAMD51
+    TC1->COUNT16.CTRLA.bit.CAPTEN0 == 1) {
+#endif
         shared_timer_handler(true, 1, false);
-        } else {
+    } else {
         shared_timer_handler(true, 1, true);
     }
 }
@@ -140,43 +150,68 @@ void TC1_Handler(void) {
 #ifdef TC2
 void TC2_Handler(void) {
     if (TC2->COUNT16.EVCTRL.bit.TCEI == 1 &&
-    (TC2->COUNT16.CTRLC.bit.CPTEN0 == 1 || TC2->COUNT16.CTRLC.bit.CPTEN1 == 1)) {
+#ifdef SAMD21
+    TC2->COUNT16.CTRLC.bit.CPTEN0 == 1) {
+#endif
+#ifdef SAMD51
+    TC2->COUNT16.CTRLA.bit.CAPTEN0 == 1) {
+#endif
         shared_timer_handler(true, 2, false);
-        } else {
+    } else {
         shared_timer_handler(true, 2, true);
     }
 }
 #endif
 void TC3_Handler(void) {
     if (TC3->COUNT16.EVCTRL.bit.TCEI == 1 &&
-    (TC3->COUNT16.CTRLC.bit.CPTEN0 == 1 || TC3->COUNT16.CTRLC.bit.CPTEN1 == 1)) {
+#ifdef SAMD21
+    TC3->COUNT16.CTRLC.bit.CPTEN0 == 1) {
+#endif
+#ifdef SAMD51
+    TC3->COUNT16.CTRLA.bit.CAPTEN0 == 1) {
+#endif
         shared_timer_handler(true, 3 - TC_OFFSET, false);
-        } else {
+    } else {
         shared_timer_handler(true, 3 - TC_OFFSET, true);
     }
 }
 void TC4_Handler(void) {
     if (TC4->COUNT16.EVCTRL.bit.TCEI == 1 &&
-    (TC4->COUNT16.CTRLC.bit.CPTEN0 == 1 || TC4->COUNT16.CTRLC.bit.CPTEN1 == 1)) {
+#ifdef SAMD21
+    TC4->COUNT16.CTRLC.bit.CPTEN0 == 1) {
+#endif
+#ifdef SAMD51
+    TC4->COUNT16.CTRLA.bit.CAPTEN0 == 1) {
+#endif
         shared_timer_handler(true, 4 - TC_OFFSET, false);
-        } else {
+    } else {
         shared_timer_handler(true, 4 - TC_OFFSET, true);
     }
 }
 void TC5_Handler(void) {
     if (TC5->COUNT16.EVCTRL.bit.TCEI == 1 &&
-    (TC5->COUNT16.CTRLC.bit.CPTEN0 == 1 || TC5->COUNT16.CTRLC.bit.CPTEN1 == 1)) {
+#ifdef SAMD21
+    TC5->COUNT16.CTRLC.bit.CPTEN0 == 1) {
+#endif
+#ifdef SAMD51
+    TC5->COUNT16.CTRLA.bit.CAPTEN0 == 1) {
+#endif
         shared_timer_handler(true, 5 - TC_OFFSET, false);
-        } else {
+    } else {
         shared_timer_handler(true, 5 - TC_OFFSET, true);
     }
 }
 #ifdef TC6
 void TC6_Handler(void) {
     if (TC6->COUNT16.EVCTRL.bit.TCEI == 1 &&
-    (TC6->COUNT16.CTRLC.bit.CPTEN0 == 1 || TC6->COUNT16.CTRLC.bit.CPTEN1 == 1)) {
+#ifdef SAMD21
+    TC6->COUNT16.CTRLC.bit.CPTEN0 == 1) {
+#endif
+#ifdef SAMD51
+    TC6->COUNT16.CTRLA.bit.CAPTEN0 == 1) {
+#endif
         shared_timer_handler(true, 6 - TC_OFFSET, false);
-        } else {
+    } else {
         shared_timer_handler(true, 6 - TC_OFFSET, true);
     }
 }
@@ -184,9 +219,14 @@ void TC6_Handler(void) {
 #ifdef TC7
 void TC7_Handler(void) {
     if (TC7->COUNT16.EVCTRL.bit.TCEI == 1 &&
-    (TC7->COUNT16.CTRLC.bit.CPTEN0 == 1 || TC7->COUNT16.CTRLC.bit.CPTEN1 == 1)) {
+#ifdef SAMD21
+    TC7->COUNT16.CTRLC.bit.CPTEN0 == 1) {
+#endif
+#ifdef SAMD51
+    TC7->COUNT16.CTRLA.bit.CAPTEN0 == 1) {
+#endif
         shared_timer_handler(true, 7 - TC_OFFSET, false);
-        } else {
+    } else {
         shared_timer_handler(true, 7 - TC_OFFSET, true);
     }
 }

--- a/samd/timers.h
+++ b/samd/timers.h
@@ -43,7 +43,7 @@ const uint8_t tcc_gclk_ids[TCC_INST_NUM];
 Tc* const tc_insts[TC_INST_NUM];
 Tcc* const tcc_insts[TCC_INST_NUM];
 
-void turn_on_clocks(bool is_tc, uint8_t index, uint32_t gclk_index);
+void turn_on_clocks(bool is_tc, uint8_t index, uint32_t gclk_index, uint8_t timer_handler);
 void tc_set_enable(Tc* tc, bool enable);
 void tcc_set_enable(Tcc* tcc, bool enable);
 void tc_wait_for_sync(Tc* tc);
@@ -51,6 +51,9 @@ void tc_reset(Tc* tc);
 
 void tc_enable_interrupts(uint8_t tc_index);
 void tc_disable_interrupts(uint8_t tc_index);
+
+extern void shared_timer_handler(bool is_tc, uint8_t index);
+extern void set_timer_handler(uint8_t index, uint8_t timer_handler);
 
 // Handlers
 void TCC0_Handler(void);


### PR DESCRIPTION
- FREQM: Added FREQM peripheral usage. `init`, `deinit`, and `read` are the available functions. I have it statically using OSCULP32K as the generator source for the reference clock, since it will always be available and the reference clock must be slower than the clock to measure. I'm sure I've missed some error handling, and it is still using some ASF4.

- FrequencyIn/TC: added FrequencyIn to the `shared_handler`, and have each `TC_Handler` determining what the interrupt is driven by. I'm not sure if there is a more elegant way to do this..

This is necessary to be merged before I can push the FrequencyIn module to CircuitPython, since I'll have to update the submodules.