### PR TITLE
Add find_free_timer() function

### DIFF
--- a/samd/timers.c
+++ b/samd/timers.c
@@ -61,6 +61,16 @@ IRQn_Type const tc_irq[TC_INST_NUM] = {
 #endif
 };
 
+uint8_t find_free_timer(void) {
+    int8_t index = TC_INST_NUM - 1;
+    for (; index >= 0; index--) {
+        if (tc_insts[index]->COUNT16.CTRLA.bit.ENABLE == 0) {
+            return index;
+        }
+    }
+    return 0xff;
+}
+
 void tc_enable_interrupts(uint8_t tc_index) {
     NVIC_DisableIRQ(tc_irq[tc_index]);
     NVIC_ClearPendingIRQ(tc_irq[tc_index]);

--- a/samd/timers.h
+++ b/samd/timers.h
@@ -48,6 +48,7 @@ void tc_set_enable(Tc* tc, bool enable);
 void tcc_set_enable(Tcc* tcc, bool enable);
 void tc_wait_for_sync(Tc* tc);
 void tc_reset(Tc* tc);
+uint8_t find_free_timer(void);
 
 void tc_enable_interrupts(uint8_t tc_index);
 void tc_disable_interrupts(uint8_t tc_index);


### PR DESCRIPTION
This was an easy one to do for [#1109](https://github.com/adafruit/circuitpython/issues/1109). 

I have updates on my local for the CircuitPython side that I'll push soon. Just updates to the construct functions for `AudioOut`, `PulseOut`, and `FrequencyIn` (pending).