### PR TITLE
remove unnecessary declarations of reset_pin()

### DIFF
--- a/samd/samd21/pins.h
+++ b/samd/samd21/pins.h
@@ -31,8 +31,6 @@
 
 #include "samd_peripherals_config.h"
 
-void reset_pin(uint8_t pin);
-
 #define MUX_C 2
 #define MUX_D 3
 #define MUX_E 4

--- a/samd/samd51/pins.h
+++ b/samd/samd51/pins.h
@@ -32,8 +32,6 @@
 
 #include "include/sam.h"
 
-void reset_pin(uint8_t pin);
-
 #define MUX_C 2
 #define MUX_D 3
 #define MUX_E 4


### PR DESCRIPTION
These declarations of `reset_pin()` aren't needed - they're declared elsewhere. circuitpython builds fine without them. 

I renamed `reset_pin()` to `reset_pin_number()` in CPy, so this is prerequisite for the circuitpython PR that includes this change.