### PR TITLE
Remove unneeded GCLK that was used by the DAC.

### DIFF
--- a/samd/samd21/clocks.c
+++ b/samd/samd21/clocks.c
@@ -182,7 +182,6 @@ void clock_init(void)
     }
 
     enable_clock_generator(0, GCLK_GENCTRL_SRC_DFLL48M_Val, 1);
-    enable_clock_generator(1, GCLK_GENCTRL_SRC_DFLL48M_Val, 150);
     if (board_has_crystal()) {
         enable_clock_generator(2, GCLK_GENCTRL_SRC_XOSC32K_Val, 32);
     } else {


### PR DESCRIPTION
The DAC can run off GCLK0 at 48mhz. It just can't be triggered for new values too quickly.