### PR TITLE
Move Timer Handler Back To /ports/atmel-samd

### DIFF
--- a/samd/samd21/timers.c
+++ b/samd/samd21/timers.c
@@ -29,7 +29,7 @@
 
 #include "samd/timers.h"
 
-//#include "common-hal/pulseio/PulseOut.h"
+#include "timer_handler.h"
 
 #include "hpl/gclk/hpl_gclk_base.h"
 
@@ -46,7 +46,7 @@ const uint8_t tc_gclk_ids[TC_INST_NUM] = {TC3_GCLK_ID,
             };
 const uint8_t tcc_gclk_ids[3] = {TCC0_GCLK_ID, TCC1_GCLK_ID, TCC2_GCLK_ID};
 
-void turn_on_clocks(bool is_tc, uint8_t index, uint32_t gclk_index) {
+void turn_on_clocks(bool is_tc, uint8_t index, uint32_t gclk_index, uint8_t timer_handler) {
     uint8_t gclk_id;
     if (is_tc) {
         gclk_id = tc_gclk_ids[index];
@@ -61,6 +61,7 @@ void turn_on_clocks(bool is_tc, uint8_t index, uint32_t gclk_index) {
     }
     PM->APBCMASK.reg |= 1 << clock_slot;
     _gclk_enable_channel(gclk_id, gclk_index);
+    set_timer_handler(index, timer_handler);
 }
 
 void tc_set_enable(Tc* tc, bool enable) {

--- a/samd/samd21/timers.c
+++ b/samd/samd21/timers.c
@@ -46,7 +46,7 @@ const uint8_t tc_gclk_ids[TC_INST_NUM] = {TC3_GCLK_ID,
             };
 const uint8_t tcc_gclk_ids[3] = {TCC0_GCLK_ID, TCC1_GCLK_ID, TCC2_GCLK_ID};
 
-void turn_on_clocks(bool is_tc, uint8_t index, uint32_t gclk_index, uint8_t timer_handler) {
+void turn_on_clocks(bool is_tc, uint8_t index, uint32_t gclk_index) {
     uint8_t gclk_id;
     if (is_tc) {
         gclk_id = tc_gclk_ids[index];
@@ -61,7 +61,6 @@ void turn_on_clocks(bool is_tc, uint8_t index, uint32_t gclk_index, uint8_t time
     }
     PM->APBCMASK.reg |= 1 << clock_slot;
     _gclk_enable_channel(gclk_id, gclk_index);
-    set_timer_handler(index, timer_handler);
 }
 
 void tc_set_enable(Tc* tc, bool enable) {

--- a/samd/samd51/timers.c
+++ b/samd/samd51/timers.c
@@ -62,7 +62,7 @@ const uint8_t tcc_gclk_ids[TCC_INST_NUM] = {TCC0_GCLK_ID,
 #endif
                                     };
 
-void turn_on_clocks(bool is_tc, uint8_t index, uint32_t gclk_index, uint8_t timer_handler) {
+void turn_on_clocks(bool is_tc, uint8_t index, uint32_t gclk_index) {
     uint8_t gclk_id;
     if (is_tc) {
         gclk_id = tc_gclk_ids[index];
@@ -71,7 +71,6 @@ void turn_on_clocks(bool is_tc, uint8_t index, uint32_t gclk_index, uint8_t time
     }
     // Turn on the clocks for the peripherals.
     if (is_tc) {
-        set_timer_handler(index, timer_handler);
         switch (index) {
             case 0:
                 MCLK->APBAMASK.reg |= MCLK_APBAMASK_TC0;

--- a/samd/samd51/timers.c
+++ b/samd/samd51/timers.c
@@ -29,6 +29,8 @@
 
 #include "samd/timers.h"
 
+#include "timer_handler.h"
+
 #include "hri/hri_gclk_d51.h"
 
 const uint8_t tcc_cc_num[5] = {6, 4, 3, 2, 2};
@@ -60,7 +62,7 @@ const uint8_t tcc_gclk_ids[TCC_INST_NUM] = {TCC0_GCLK_ID,
 #endif
                                     };
 
-void turn_on_clocks(bool is_tc, uint8_t index, uint32_t gclk_index) {
+void turn_on_clocks(bool is_tc, uint8_t index, uint32_t gclk_index, uint8_t timer_handler) {
     uint8_t gclk_id;
     if (is_tc) {
         gclk_id = tc_gclk_ids[index];
@@ -69,6 +71,7 @@ void turn_on_clocks(bool is_tc, uint8_t index, uint32_t gclk_index) {
     }
     // Turn on the clocks for the peripherals.
     if (is_tc) {
+        set_timer_handler(index, timer_handler);
         switch (index) {
             case 0:
                 MCLK->APBAMASK.reg |= MCLK_APBAMASK_TC0;

--- a/samd/timers.c
+++ b/samd/timers.c
@@ -29,8 +29,6 @@
 
 #include "timers.h"
 
-#include "common-hal/pulseio/PulseOut.h"
-
 const uint16_t prescaler[8] = {1, 2, 4, 8, 16, 64, 256, 1024};
 
 Tc* const tc_insts[TC_INST_NUM] = TC_INSTS;
@@ -94,13 +92,6 @@ void tcc_set_enable(Tcc* tcc, bool enable) {
 void tc_reset(Tc* tc) {
     tc->COUNT16.CTRLA.bit.SWRST = 1;
     while (tc->COUNT16.CTRLA.bit.SWRST == 1) {
-    }
-}
-
-void shared_timer_handler(bool is_tc, uint8_t index) {
-    // Add calls to interrupt handlers for specific functionality here.
-    if (is_tc) {
-        pulseout_interrupt_handler(index);
     }
 }
 

--- a/samd/timers.h
+++ b/samd/timers.h
@@ -43,7 +43,7 @@ const uint8_t tcc_gclk_ids[TCC_INST_NUM];
 Tc* const tc_insts[TC_INST_NUM];
 Tcc* const tcc_insts[TCC_INST_NUM];
 
-void turn_on_clocks(bool is_tc, uint8_t index, uint32_t gclk_index, uint8_t timer_handler);
+void turn_on_clocks(bool is_tc, uint8_t index, uint32_t gclk_index);
 void tc_set_enable(Tc* tc, bool enable);
 void tcc_set_enable(Tcc* tcc, bool enable);
 void tc_wait_for_sync(Tc* tc);
@@ -54,7 +54,6 @@ void tc_enable_interrupts(uint8_t tc_index);
 void tc_disable_interrupts(uint8_t tc_index);
 
 extern void shared_timer_handler(bool is_tc, uint8_t index);
-extern void set_timer_handler(uint8_t index, uint8_t timer_handler);
 
 // Handlers
 void TCC0_Handler(void);

--- a/samd/timers.h
+++ b/samd/timers.h
@@ -43,7 +43,7 @@ const uint8_t tcc_gclk_ids[TCC_INST_NUM];
 Tc* const tc_insts[TC_INST_NUM];
 Tcc* const tcc_insts[TCC_INST_NUM];
 
-void turn_on_clocks(bool is_tc, uint8_t index, uint32_t gclk_index);
+void turn_on_clocks(bool is_tc, uint8_t index, uint32_t gclk_index, uint8_t timer_handler);
 void tc_set_enable(Tc* tc, bool enable);
 void tcc_set_enable(Tcc* tcc, bool enable);
 void tc_wait_for_sync(Tc* tc);
@@ -52,6 +52,9 @@ uint8_t find_free_timer(void);
 
 void tc_enable_interrupts(uint8_t tc_index);
 void tc_disable_interrupts(uint8_t tc_index);
+
+extern void shared_timer_handler(bool is_tc, uint8_t index);
+extern void set_timer_handler(uint8_t index, uint8_t timer_handler);
 
 // Handlers
 void TCC0_Handler(void);


### PR DESCRIPTION
This is partially reverting #8. This doesn't include the FREQM part, since use of that has been abandoned.

Purpose is to make it easier to handle or add TC/TCC interrupt handlers, without further updates to `samd-peripherals`.
EDIT: scrolling through core issues, and forgot that this is also step 2 for [#1109](https://github.com/adafruit/circuitpython/issues/1109).

If/after this is merged, I have changes to the core waiting. Just need the submodule update.

