### PR TITLE
Remove CPy-specific external interrupt handlers

### DIFF
--- a/samd/external_interrupts.c
+++ b/samd/external_interrupts.c
@@ -35,16 +35,14 @@
 // Without this there would be multiple arrays even though they are disjoint because each channel
 // has one user.
 static void *channel_data[EIC_EXTINT_NUM];
-static uint8_t channel_handler[EIC_EXTINT_NUM];
+static channel_interrupt_handler_t channel_interrupt_handler[EIC_EXTINT_NUM];
 
 void external_interrupt_handler(uint8_t channel) {
-    uint8_t handler = channel_handler[channel];
-    if (handler == EIC_HANDLER_PULSEIN) {
-        pulsein_interrupt_handler(channel);
-    } else if (handler == EIC_HANDLER_INCREMENTAL_ENCODER) {
-        incrementalencoder_interrupt_handler(channel);
+    channel_interrupt_handler_t handler = channel_interrupt_handler[channel];
+    if (handler) {
+        channel_interrupt_handler[channel](channel);
+        EIC->INTFLAG.reg = (1 << channel) << EIC_INTFLAG_EXTINT_Pos;
     }
-    EIC->INTFLAG.reg = (1 << channel) << EIC_INTFLAG_EXTINT_Pos;
 }
 
 void configure_eic_channel(uint8_t eic_channel, uint32_t sense_setting) {
@@ -63,14 +61,15 @@ void configure_eic_channel(uint8_t eic_channel, uint32_t sense_setting) {
 }
 
 void turn_on_eic_channel(uint8_t eic_channel, uint32_t sense_setting,
-                         uint8_t channel_interrupt_handler) {
+                         channel_interrupt_handler_t handler) {
     // We do very light filtering using majority voting.
     sense_setting |= EIC_CONFIG_FILTEN0;
     configure_eic_channel(eic_channel, sense_setting);
     uint32_t mask = 1 << eic_channel;
     EIC->INTENSET.reg = mask << EIC_INTENSET_EXTINT_Pos;
-    if (channel_interrupt_handler != EIC_HANDLER_NO_INTERRUPT) {
-        channel_handler[eic_channel] = channel_interrupt_handler;
+    // handler might be NULL.
+    channel_interrupt_handler[eic_channel] = handler;
+    if (handler) {
         turn_on_cpu_interrupt(eic_channel);
     }
 }

--- a/samd/external_interrupts.h
+++ b/samd/external_interrupts.h
@@ -30,15 +30,13 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#define EIC_HANDLER_NO_INTERRUPT 0x0
-#define EIC_HANDLER_PULSEIN 0x1
-#define EIC_HANDLER_INCREMENTAL_ENCODER 0x2
+typedef void (*channel_interrupt_handler_t)(uint8_t);
 
 void turn_on_external_interrupt_controller(void);
 void turn_off_external_interrupt_controller(void);
 void turn_on_cpu_interrupt(uint8_t eic_channel);
 void turn_on_eic_channel(uint8_t eic_channel, uint32_t sense_setting,
-                         uint8_t channel_interrupt_handler);
+                         channel_interrupt_handler_t channel_interrupt_handler);
 void configure_eic_channel(uint8_t eic_channel, uint32_t sense_setting);
 void turn_off_eic_channel(uint8_t eic_channel);
 bool eic_channel_free(uint8_t eic_channel);


### PR DESCRIPTION
Now you just pass in a pointer to an external interrupt handler routine, instead of a CircuitPython-specific `uint8_t` that indicates which CircuitPython interrupt handler to call. This takes 16*4 bytes of RAM instead of just 16, to store possible interrupt handler addresses, but it removes any need to know the interrupt handler routines in this code.

Fixes #20.

Tested with rotaryio and pulseio.