### PR TITLE
Remove CircuitPython-specific EIC handler info

### DIFF
--- a/samd/external_interrupts.h
+++ b/samd/external_interrupts.h
@@ -30,15 +30,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#define EIC_HANDLER_NO_INTERRUPT 0x0
-#define EIC_HANDLER_PULSEIN 0x1
-#define EIC_HANDLER_INCREMENTAL_ENCODER 0x2
-
 void turn_on_external_interrupt_controller(void);
 void turn_off_external_interrupt_controller(void);
 void turn_on_cpu_interrupt(uint8_t eic_channel);
-void turn_on_eic_channel(uint8_t eic_channel, uint32_t sense_setting,
-                         uint8_t channel_interrupt_handler);
+void turn_on_eic_channel(uint8_t eic_channel, uint32_t sense_setting);
 void configure_eic_channel(uint8_t eic_channel, uint32_t sense_setting);
 void turn_off_eic_channel(uint8_t eic_channel);
 bool eic_channel_free(uint8_t eic_channel);
@@ -50,5 +45,9 @@ void* get_eic_channel_data(uint8_t eic_channel);
 void set_eic_channel_data(uint8_t eic_channel, void* data);
 
 void external_interrupt_handler(uint8_t channel);
+
+// Callback from external_interrupt_handler() to application-specific handler.
+extern void shared_eic_handler(uint8_t channel);
+
 
 #endif  // MICROPY_INCLUDED_ATMEL_SAMD_PERIPHERALS_EXTERNAL_INTERRUPTS_H


### PR DESCRIPTION
Refactored to be similar to timer handler, per discussion in #21. Closing that in favor of this.

There will momentarily be a new `circuitpython` draft PR that shows the changes on the CPy side.

Tested using `PulseIn` and `IncrementalEncoder`.