### PR TITLE
Fix for loop direction.

### DIFF
--- a/samd/samd21/clocks.c
+++ b/samd/samd21/clocks.c
@@ -71,7 +71,7 @@ void enable_clock_generator(uint8_t gclk, uint32_t source, uint16_t divisor) {
     uint32_t divsel = 0;
     if (gclk == 2 && divisor > 31) {
         divsel = GCLK_GENCTRL_DIVSEL;
-        for (int i = 15; i > 4; i++) {
+        for (int i = 15; i > 4; i--) {
             if (divisor & (1 << i)) {
                 divisor = i - 1;
                 break;


### PR DESCRIPTION
This happened to work before because ARM masks shift counts to 8 bits and the lowest and highest set bit are the same as long as `divisor` is a power of two.