### PR TITLE
clocks: Provide a 12MHz clock for the DAC

### DIFF
--- a/samd/samd51/clocks.c
+++ b/samd/samd51/clocks.c
@@ -121,6 +121,7 @@ void clock_init(void) {
     enable_clock_generator_sync(1, GCLK_GENCTRL_SRC_DFLL_Val, 1, false);
     enable_clock_generator_sync(4, GCLK_GENCTRL_SRC_DPLL0_Val, 1, false);
     enable_clock_generator_sync(5, GCLK_GENCTRL_SRC_DFLL_Val, 24, false);
+    enable_clock_generator_sync(6, GCLK_GENCTRL_SRC_DFLL_Val, 4, false);
 
     init_clock_source_dpll0();
 


### PR DESCRIPTION
Arduino operates the DAC with a 12MHz clock.  This is one step of resolving various issues in CircuitPython such as https://github.com/adafruit/circuitpython/issues/1992