### PR TITLE
Remove CircuitPython dependencies from clock code

### DIFF
--- a/samd/clocks.h
+++ b/samd/clocks.h
@@ -31,7 +31,6 @@
 #include <stdint.h>
 
 #include "include/sam.h"
-#include "mpconfigboard.h" // for BOARD_HAS_CRYSTAL
 
 #ifdef SAMD51
 #define CLOCK_48MHZ GCLK_GENCTRL_SRC_DFLL_Val
@@ -39,6 +38,9 @@
 #ifdef SAMD21
 #define CLOCK_48MHZ GCLK_GENCTRL_SRC_DFLL48M_Val
 #endif
+
+// Pass to clock_init() if fine calibration not known.
+#define DEFAULT_DFLL48M_FINE_CALIBRATION 512
 
 #define CORE_GCLK 0
 
@@ -54,15 +56,7 @@ void disconnect_gclk_from_peripheral(uint8_t gclk, uint8_t peripheral);
 void enable_clock_generator(uint8_t gclk, uint32_t source, uint16_t divisor);
 void disable_clock_generator(uint8_t gclk);
 
-static inline bool board_has_crystal(void) {
-#ifdef BOARD_HAS_CRYSTAL
-    return BOARD_HAS_CRYSTAL == 1;
-#else
-    return false;
-#endif
-}
-
-void clock_init(void);
+void clock_init(bool has_crystal, uint32_t dfll48m_fine_calibration);
 void init_dynamic_clocks(void);
 
 bool clock_get_enabled(uint8_t type, uint8_t index);
@@ -70,6 +64,5 @@ bool clock_get_parent(uint8_t type, uint8_t index, uint8_t *p_type, uint8_t *p_i
 uint32_t clock_get_frequency(uint8_t type, uint8_t index);
 uint32_t clock_get_calibration(uint8_t type, uint8_t index);
 int clock_set_calibration(uint8_t type, uint8_t index, uint32_t val);
-void save_usb_clock_calibration(void);
 
 #endif  // MICROPY_INCLUDED_ATMEL_SAMD_CLOCKS_H

--- a/samd/samd51/clocks.c
+++ b/samd/samd51/clocks.c
@@ -28,11 +28,6 @@
 
 #include "hpl_gclk_config.h"
 
-#include "bindings/samd/Clock.h"
-#include "shared-bindings/microcontroller/__init__.h"
-
-#include "py/runtime.h"
-
 bool gclk_enabled(uint8_t gclk) {
     return GCLK->GENCTRL[gclk].bit.GENEN;
 }
@@ -103,12 +98,13 @@ static void init_clock_source_dpll0(void)
     while (!(OSCCTRL->Dpll[0].DPLLSTATUS.bit.LOCK || OSCCTRL->Dpll[0].DPLLSTATUS.bit.CLKRDY)) {}
 }
 
-void clock_init(void) {
+void clock_init(bool has_crystal, uint32_t dfll48m_fine_calibration) {
     // DFLL48M is enabled by default
+    // TODO: handle fine calibration data.
 
     init_clock_source_osculp32k();
 
-    if (board_has_crystal()) {
+    if (has_crystal) {
         init_clock_source_xosc32k();
         OSC32KCTRL->RTCCTRL.bit.RTCSEL = OSC32KCTRL_RTCCTRL_RTCSEL_XOSC1K_Val;
     } else {
@@ -339,143 +335,3 @@ int clock_set_calibration(uint8_t type, uint8_t index, uint32_t val) {
     }
     return -2;
 }
-
-
-void save_usb_clock_calibration(void) {
-}
-
-#include <instance/can0.h>
-#include <instance/can1.h>
-#include <instance/i2s.h>
-#include <instance/sdhc1.h>
-#include <instance/sercom6.h>
-#include <instance/sercom7.h>
-#include <instance/tcc4.h>
-
-CLOCK_SOURCE(XOSC0);
-CLOCK_SOURCE(XOSC1);
-CLOCK_SOURCE(GCLKIN);
-CLOCK_SOURCE(GCLKGEN1);
-CLOCK_SOURCE(OSCULP32K);
-CLOCK_SOURCE(XOSC32K);
-CLOCK_SOURCE(DFLL);
-CLOCK_SOURCE(DPLL0);
-CLOCK_SOURCE(DPLL1);
-
-CLOCK_GCLK_(OSCCTRL, DFLL48);
-CLOCK_GCLK_(OSCCTRL, FDPLL0);
-CLOCK_GCLK_(OSCCTRL, FDPLL1);
-CLOCK_GCLK_(OSCCTRL, FDPLL032K); // GCLK_OSCCTRL_FDPLL1_32K, GCLK_SDHC0_SLOW, GCLK_SDHC1_SLOW, GCLK_SERCOM[0..7]_SLOW
-CLOCK_GCLK(EIC);
-CLOCK_GCLK_(FREQM, MSR);
-// 6: GCLK_FREQM_REF
-CLOCK_GCLK_(SERCOM0, CORE);
-CLOCK_GCLK_(SERCOM1, CORE);
-CLOCK(TC0_TC1, 1, 9);
-CLOCK_GCLK(USB);
-CLOCK_GCLK_(EVSYS, 0);
-CLOCK_GCLK_(EVSYS, 1);
-CLOCK_GCLK_(EVSYS, 2);
-CLOCK_GCLK_(EVSYS, 3);
-CLOCK_GCLK_(EVSYS, 4);
-CLOCK_GCLK_(EVSYS, 5);
-CLOCK_GCLK_(EVSYS, 6);
-CLOCK_GCLK_(EVSYS, 7);
-CLOCK_GCLK_(EVSYS, 8);
-CLOCK_GCLK_(EVSYS, 9);
-CLOCK_GCLK_(EVSYS, 10);
-CLOCK_GCLK_(EVSYS, 11);
-CLOCK_GCLK_(SERCOM2, CORE);
-CLOCK_GCLK_(SERCOM3, CORE);
-CLOCK(TCC0_TCC1, 1, 25);
-CLOCK(TC2_TC3, 1, 26);
-CLOCK_GCLK(CAN0);
-CLOCK_GCLK(CAN1);
-CLOCK(TCC2_TCC3, 1, 29);
-CLOCK(TC4_TC5, 1, 30);
-// CLOCK_GCLK(PDEC);
-// CLOCK_GCLK(AC);
-// CLOCK_GCLK(CCL);
-CLOCK_GCLK_(SERCOM4, CORE);
-CLOCK_GCLK_(SERCOM5, CORE);
-CLOCK_GCLK_(SERCOM6, CORE);
-CLOCK_GCLK_(SERCOM7, CORE);
-CLOCK_GCLK(TCC4);
-CLOCK(TC6_TC7, 1, 39);
-CLOCK_GCLK(ADC0);
-CLOCK_GCLK(ADC1);
-CLOCK_GCLK(DAC);
-CLOCK_GCLK_(I2S, 0);
-CLOCK_GCLK_(I2S, 1);
-// CLOCK_GCLK(SDHC0);
-// CLOCK_GCLK(SDHC1);
-// 47: GCLK_CM4_TRACE
-
-CLOCK(SYSTICK, 2, 0);
-CLOCK(CPU, 2, 1);
-CLOCK(RTC, 2, 2);
-
-
-STATIC const mp_rom_map_elem_t samd_clock_global_dict_table[] = {
-    CLOCK_ENTRY(XOSC0),
-    CLOCK_ENTRY(XOSC1),
-    CLOCK_ENTRY(GCLKIN),
-    CLOCK_ENTRY(GCLKGEN1),
-    CLOCK_ENTRY(OSCULP32K),
-    CLOCK_ENTRY(XOSC32K),
-    CLOCK_ENTRY(DFLL),
-    CLOCK_ENTRY(DPLL0),
-    CLOCK_ENTRY(DPLL1),
-
-    CLOCK_ENTRY_(OSCCTRL, DFLL48),
-    CLOCK_ENTRY_(OSCCTRL, FDPLL0),
-    CLOCK_ENTRY_(OSCCTRL, FDPLL1),
-    CLOCK_ENTRY_(OSCCTRL, FDPLL032K),
-    CLOCK_ENTRY(EIC),
-    CLOCK_ENTRY_(FREQM, MSR),
-    CLOCK_ENTRY_(SERCOM0, CORE),
-    CLOCK_ENTRY_(SERCOM1, CORE),
-    CLOCK_ENTRY(TC0_TC1),
-    CLOCK_ENTRY(USB),
-    CLOCK_ENTRY_(EVSYS, 0),
-    CLOCK_ENTRY_(EVSYS, 1),
-    CLOCK_ENTRY_(EVSYS, 2),
-    CLOCK_ENTRY_(EVSYS, 3),
-    CLOCK_ENTRY_(EVSYS, 4),
-    CLOCK_ENTRY_(EVSYS, 5),
-    CLOCK_ENTRY_(EVSYS, 6),
-    CLOCK_ENTRY_(EVSYS, 7),
-    CLOCK_ENTRY_(EVSYS, 8),
-    CLOCK_ENTRY_(EVSYS, 9),
-    CLOCK_ENTRY_(EVSYS, 10),
-    CLOCK_ENTRY_(EVSYS, 11),
-    CLOCK_ENTRY_(SERCOM2, CORE),
-    CLOCK_ENTRY_(SERCOM3, CORE),
-    CLOCK_ENTRY(TCC0_TCC1),
-    CLOCK_ENTRY(TC2_TC3),
-    CLOCK_ENTRY(CAN0),
-    CLOCK_ENTRY(CAN1),
-    CLOCK_ENTRY(TCC2_TCC3),
-    CLOCK_ENTRY(TC4_TC5),
-    // CLOCK_ENTRY(PDEC),
-    // CLOCK_ENTRY(AC),
-    // CLOCK_ENTRY(CCL),
-    CLOCK_ENTRY_(SERCOM4, CORE),
-    CLOCK_ENTRY_(SERCOM5, CORE),
-    CLOCK_ENTRY_(SERCOM6, CORE),
-    CLOCK_ENTRY_(SERCOM7, CORE),
-    CLOCK_ENTRY(TCC4),
-    CLOCK_ENTRY(TC6_TC7),
-    CLOCK_ENTRY(ADC0),
-    CLOCK_ENTRY(ADC1),
-    CLOCK_ENTRY(DAC),
-    CLOCK_ENTRY_(I2S, 0),
-    CLOCK_ENTRY_(I2S, 1),
-    // CLOCK_ENTRY(SDHC0),
-    // CLOCK_ENTRY(SDHC1),
-
-    CLOCK_ENTRY(SYSTICK),
-    CLOCK_ENTRY(CPU),
-    CLOCK_ENTRY(RTC),
-};
-MP_DEFINE_CONST_DICT(samd_clock_globals, samd_clock_global_dict_table);


### PR DESCRIPTION
Fixes #18 

Remove CircuitPython dependencies from the clock-related code. Preprocessor define values are now passed in as args. `samd` module-related code moved back to CircuitPython (circuitpython PR in preparation).

There is still some CircuitPython-dependent code in the dma and external-interrupt routines.