### PR TITLE
samd51: Work around DMA hang

### DIFF
--- a/samd/dma.c
+++ b/samd/dma.c
@@ -185,6 +185,7 @@ static int32_t shared_dma_transfer(void* peripheral,
 
     // Channels cycle between Suspend -> Pending -> Busy and back while transfering. So, we check
     // the channels transfer status for an error or completion.
+    // (However, the flags being checked here are actually CHINTFLAG "complete" and "error")
     if (rx_active) {
         while ((dma_transfer_status(SHARED_RX_CHANNEL) & 0x3) == 0) {}
     }

--- a/samd/dma.c
+++ b/samd/dma.c
@@ -110,7 +110,6 @@ static int32_t shared_dma_transfer(void* peripheral,
     } else {
     #endif
 
-        // sercom index is incorrect for SAMD51
         dma_configure(SHARED_TX_CHANNEL, sercom_index(peripheral) * 2 + FIRST_SERCOM_TX_TRIGSRC, false);
         tx_active = true;
         if (buffer_in != NULL) {
@@ -155,8 +154,6 @@ static int32_t shared_dma_transfer(void* peripheral,
     if (sercom) {
         SercomSpi *s = &((Sercom*) peripheral)->SPI;
         s->INTFLAG.reg = SERCOM_SPI_INTFLAG_RXC | SERCOM_SPI_INTFLAG_DRE;
-    } else {
-        //QSPI->INTFLAG.reg = QSPI_INTFLAG_RXC | QSPI_INTFLAG_DRE;
     }
     // Start the RX job first so we don't miss the first byte. The TX job clocks
     // the output.
@@ -168,19 +165,10 @@ static int32_t shared_dma_transfer(void* peripheral,
     }
 
 
-    if (sercom) {
-        //DMAC->SWTRIGCTRL.reg |= (1 << SHARED_TX_CHANNEL);
-    } else {
-        // Do a manual copy to trigger then DMA. We do 32-bit accesses to match the DMA.
-        #pragma GCC diagnostic push
-        #pragma GCC diagnostic ignored "-Wcast-align"
+    if (!sercom) {
         if (rx_active) {
-            //buffer_in[0] = *src;
             DMAC->SWTRIGCTRL.reg |= (1 << SHARED_RX_CHANNEL);
-        } else {
-            //*(uint32_t*)dest = ((uint32_t*) buffer_out)[0];
         }
-        #pragma GCC diagnostic pop
     }
 
     #ifdef SAMD51
@@ -211,9 +199,7 @@ static int32_t shared_dma_transfer(void* peripheral,
     }
     #endif
 
-    // Channels cycle between Suspend -> Pending -> Busy and back while transfering. So, we check
-    // the channels transfer status for an error or completion.
-    // (However, the flags being checked here are actually CHINTFLAG "complete" and "error")
+    // busy-wait for the RX and TX DMAs to either complete or encounter an error
     if (rx_active) {
         while ((dma_transfer_status(SHARED_RX_CHANNEL) & 0x3) == 0) {}
     }


### PR DESCRIPTION
There's a hang when using multiple DMA channels on SAMD51 that has affected several projects based on CircuitPython and on Arduino (nofrendo_arcada).

This patch attempts to address the DMA hang for Circuitpython, in the specific case where audio hangs while doing DMA for display.  It should also help if there are DMA hangs while doing other SPI or QSPI activity, but I never personally observed a hang other than from display-during-audio.

There's no particular reason I chose 10 iterations for the loop; in CircuitPython, we know that there are at least 16 bytes of transfer to do, so probably checking 10 times in a row wouldn't lengthen a short transaction.

Testing performed: On a pygamer, with an additional local patch that tracked the number of times the (!is_okay) branch was entered, I found that it was entered around 2-3 times per hour during my audio playback with display test, and zero hangs were observed.

Because I was not in the room when it was playing, I didn't hear whether audible glitches occur.