### PR TITLE
timers.h: Add prerequisite include

### DIFF
--- a/samd/timers.h
+++ b/samd/timers.h
@@ -26,6 +26,7 @@
 #ifndef MICROPY_INCLUDED_ATMEL_SAMD_TIMERS_H
 #define MICROPY_INCLUDED_ATMEL_SAMD_TIMERS_H
 
+#include <stdbool.h>
 #include "include/sam.h"
 
 const uint16_t prescaler[8];


### PR DESCRIPTION
This header refers to the bool type, so it should include <stdbool.h>.