### PR TITLE
Add SAM E51 support

### DIFF
--- a/samd/sam_d5x_e5x/hri_gclk.h
+++ b/samd/sam_d5x_e5x/hri_gclk.h
@@ -27,10 +27,15 @@
 #ifndef MICROPY_INCLUDED_ATMEL_SAMD_HRI_GCLK_H
 #define MICROPY_INCLUDED_ATMEL_SAMD_HRI_GCLK_H
 
-#ifdef SAMD51
+#if defined(SAMD51)
 #include "hri/hri_gclk_d51.h"
-#else
+#elif defined(SAME51)
+#include "sam.h"
+#include "hri/hri_gclk_e51.h"
+#elif defined(SAME54)
 #include "hri/hri_gclk_e54.h"
+#else
+#error Unknown chip family
 #endif
 
 #endif

--- a/samd/sam_d5x_e5x/hri_mclk.h
+++ b/samd/sam_d5x_e5x/hri_mclk.h
@@ -27,10 +27,15 @@
 #ifndef MICROPY_INCLUDED_ATMEL_SAMD_HRI_MCLK_H
 #define MICROPY_INCLUDED_ATMEL_SAMD_HRI_MCLK_H
 
-#ifdef SAMD51
+#if defined(SAMD51)
 #include "hri/hri_mclk_d51.h"
-#else
+#elif defined(SAME51)
+#include "hri/hri_mclk_e51.h"
+#elif defined(SAME54)
+#include "sam.h"
 #include "hri/hri_mclk_e54.h"
+#else
+#error Unknown chip family
 #endif
 
 #endif


### PR DESCRIPTION
Additionally, an error will be given when an unknown chip family is passed in, instead of silently skipping a required header.