### PR TITLE
Fix audio pause property not updating correctly

### DIFF
--- a/samd/sam_d5x_e5x/dma.c
+++ b/samd/sam_d5x_e5x/dma.c
@@ -76,6 +76,7 @@ void dma_suspend_channel(uint8_t channel_number) {
 void dma_resume_channel(uint8_t channel_number) {
     DmacChannel* channel = &DMAC->Channel[channel_number];
     channel->CHCTRLB.reg = DMAC_CHCTRLB_CMD_RESUME;
+    channel->CHINTFLAG.reg = DMAC_CHINTFLAG_SUSP;
 }
 
 bool dma_channel_enabled(uint8_t channel_number) {


### PR DESCRIPTION
On the SAMD51 after an audio clip is paused and then resumed the paused() function would continue to return True

The fix is to clear suspend flag (by writing to it) after dma_resume_channel is called.

Fixes [CP Issue 2374](https://github.com/adafruit/circuitpython/issues/2374)