### PR TITLE
pins.h: Don't declare pins which are IGNOREd

### DIFF
--- a/samd/sam_d5x_e5x/pins.h
+++ b/samd/sam_d5x_e5x/pins.h
@@ -41,307 +41,307 @@
 #define NO_PIN PORT_BITS
 
 // Pins in datasheet order.
-#ifdef PIN_PB03
+#if defined(PIN_PB03) && !defined(IGNORE_PIN_PB03)
 extern const mcu_pin_obj_t pin_PB03;
 #endif
-#ifdef PIN_PA00
+#if defined(PIN_PA00) && !defined(IGNORE_PIN_PA00)
 extern const mcu_pin_obj_t pin_PA00;
 #endif
-#ifdef PIN_PA01
+#if defined(PIN_PA01) && !defined(IGNORE_PIN_PA01)
 extern const mcu_pin_obj_t pin_PA01;
 #endif
-#ifdef PIN_PC00
+#if defined(PIN_PC00) && !defined(IGNORE_PIN_PC00)
 extern const mcu_pin_obj_t pin_PC00;
 #endif
-#ifdef PIN_PC01
+#if defined(PIN_PC01) && !defined(IGNORE_PIN_PC01)
 extern const mcu_pin_obj_t pin_PC01;
 #endif
-#ifdef PIN_PC02
+#if defined(PIN_PC02) && !defined(IGNORE_PIN_PC02)
 extern const mcu_pin_obj_t pin_PC02;
 #endif
-#ifdef PIN_PC03
+#if defined(PIN_PC03) && !defined(IGNORE_PIN_PC03)
 extern const mcu_pin_obj_t pin_PC03;
 #endif
-#ifdef PIN_PA02
+#if defined(PIN_PA02) && !defined(IGNORE_PIN_PA02)
 extern const mcu_pin_obj_t pin_PA02;
 #endif
-#ifdef PIN_PA03
+#if defined(PIN_PA03) && !defined(IGNORE_PIN_PA03)
 extern const mcu_pin_obj_t pin_PA03;
 #endif
-#ifdef PIN_PB04
+#if defined(PIN_PB04) && !defined(IGNORE_PIN_PB04)
 extern const mcu_pin_obj_t pin_PB04;
 #endif
-#ifdef PIN_PB05
+#if defined(PIN_PB05) && !defined(IGNORE_PIN_PB05)
 extern const mcu_pin_obj_t pin_PB05;
 #endif
-#ifdef PIN_PD00
+#if defined(PIN_PD00) && !defined(IGNORE_PIN_PD00)
 extern const mcu_pin_obj_t pin_PD00;
 #endif
-#ifdef PIN_PD01
+#if defined(PIN_PD01) && !defined(IGNORE_PIN_PD01)
 extern const mcu_pin_obj_t pin_PD01;
 #endif
-#ifdef PIN_PB06
+#if defined(PIN_PB06) && !defined(IGNORE_PIN_PB06)
 extern const mcu_pin_obj_t pin_PB06;
 #endif
-#ifdef PIN_PB07
+#if defined(PIN_PB07) && !defined(IGNORE_PIN_PB07)
 extern const mcu_pin_obj_t pin_PB07;
 #endif
-#ifdef PIN_PB08
+#if defined(PIN_PB08) && !defined(IGNORE_PIN_PB08)
 extern const mcu_pin_obj_t pin_PB08;
 #endif
-#ifdef PIN_PB09
+#if defined(PIN_PB09) && !defined(IGNORE_PIN_PB09)
 extern const mcu_pin_obj_t pin_PB09;
 #endif
-#ifdef PIN_PA04
+#if defined(PIN_PA04) && !defined(IGNORE_PIN_PA04)
 extern const mcu_pin_obj_t pin_PA04;
 #endif
-#ifdef PIN_PA05
+#if defined(PIN_PA05) && !defined(IGNORE_PIN_PA05)
 extern const mcu_pin_obj_t pin_PA05;
 #endif
-#ifdef PIN_PA06
+#if defined(PIN_PA06) && !defined(IGNORE_PIN_PA06)
 extern const mcu_pin_obj_t pin_PA06;
 #endif
 
 // Second page
-#ifdef PIN_PA07
+#if defined(PIN_PA07) && !defined(IGNORE_PIN_PA07)
 extern const mcu_pin_obj_t pin_PA07;
 #endif
-#ifdef PIN_PC04
+#if defined(PIN_PC04) && !defined(IGNORE_PIN_PC04)
 extern const mcu_pin_obj_t pin_PC04;
 #endif
-#ifdef PIN_PC05
+#if defined(PIN_PC05) && !defined(IGNORE_PIN_PC05)
 extern const mcu_pin_obj_t pin_PC05;
 #endif
-#ifdef PIN_PC06
+#if defined(PIN_PC06) && !defined(IGNORE_PIN_PC06)
 extern const mcu_pin_obj_t pin_PC06;
 #endif
-#ifdef PIN_PC07
+#if defined(PIN_PC07) && !defined(IGNORE_PIN_PC07)
 extern const mcu_pin_obj_t pin_PC07;
 #endif
-#ifdef PIN_PA08
+#if defined(PIN_PA08) && !defined(IGNORE_PIN_PA08)
 extern const mcu_pin_obj_t pin_PA08;
 #endif
-#ifdef PIN_PA09
+#if defined(PIN_PA09) && !defined(IGNORE_PIN_PA09)
 extern const mcu_pin_obj_t pin_PA09;
 #endif
-#ifdef PIN_PA10
+#if defined(PIN_PA10) && !defined(IGNORE_PIN_PA10)
 extern const mcu_pin_obj_t pin_PA10;
 #endif
-#ifdef PIN_PA11
+#if defined(PIN_PA11) && !defined(IGNORE_PIN_PA11)
 extern const mcu_pin_obj_t pin_PA11;
 #endif
-#ifdef PIN_PB10
+#if defined(PIN_PB10) && !defined(IGNORE_PIN_PB10)
 extern const mcu_pin_obj_t pin_PB10;
 #endif
-#ifdef PIN_PB11
+#if defined(PIN_PB11) && !defined(IGNORE_PIN_PB11)
 extern const mcu_pin_obj_t pin_PB11;
 #endif
-#ifdef PIN_PB12
+#if defined(PIN_PB12) && !defined(IGNORE_PIN_PB12)
 extern const mcu_pin_obj_t pin_PB12;
 #endif
-#ifdef PIN_PB13
+#if defined(PIN_PB13) && !defined(IGNORE_PIN_PB13)
 extern const mcu_pin_obj_t pin_PB13;
 #endif
-#ifdef PIN_PB14
+#if defined(PIN_PB14) && !defined(IGNORE_PIN_PB14)
 extern const mcu_pin_obj_t pin_PB14;
 #endif
-#ifdef PIN_PB15
+#if defined(PIN_PB15) && !defined(IGNORE_PIN_PB15)
 extern const mcu_pin_obj_t pin_PB15;
 #endif
-#ifdef PIN_PD08
+#if defined(PIN_PD08) && !defined(IGNORE_PIN_PD08)
 extern const mcu_pin_obj_t pin_PD08;
 #endif
-#ifdef PIN_PD09
+#if defined(PIN_PD09) && !defined(IGNORE_PIN_PD09)
 extern const mcu_pin_obj_t pin_PD09;
 #endif
-#ifdef PIN_PD10
+#if defined(PIN_PD10) && !defined(IGNORE_PIN_PD10)
 extern const mcu_pin_obj_t pin_PD10;
 #endif
-#ifdef PIN_PD11
+#if defined(PIN_PD11) && !defined(IGNORE_PIN_PD11)
 extern const mcu_pin_obj_t pin_PD11;
 #endif
-#ifdef PIN_PD12
+#if defined(PIN_PD12) && !defined(IGNORE_PIN_PD12)
 extern const mcu_pin_obj_t pin_PD12;
 #endif
-#ifdef PIN_PC10
+#if defined(PIN_PC10) && !defined(IGNORE_PIN_PC10)
 extern const mcu_pin_obj_t pin_PC10;
 #endif
-#ifdef PIN_PC11
+#if defined(PIN_PC11) && !defined(IGNORE_PIN_PC11)
 extern const mcu_pin_obj_t pin_PC11;
 #endif
-#ifdef PIN_PC12
+#if defined(PIN_PC12) && !defined(IGNORE_PIN_PC12)
 extern const mcu_pin_obj_t pin_PC12;
 #endif
-#ifdef PIN_PC13
+#if defined(PIN_PC13) && !defined(IGNORE_PIN_PC13)
 extern const mcu_pin_obj_t pin_PC13;
 #endif
-#ifdef PIN_PC14
+#if defined(PIN_PC14) && !defined(IGNORE_PIN_PC14)
 extern const mcu_pin_obj_t pin_PC14;
 #endif
-#ifdef PIN_PC15
+#if defined(PIN_PC15) && !defined(IGNORE_PIN_PC15)
 extern const mcu_pin_obj_t pin_PC15;
 #endif
-#ifdef PIN_PA12
+#if defined(PIN_PA12) && !defined(IGNORE_PIN_PA12)
 extern const mcu_pin_obj_t pin_PA12;
 #endif
-#ifdef PIN_PA13
+#if defined(PIN_PA13) && !defined(IGNORE_PIN_PA13)
 extern const mcu_pin_obj_t pin_PA13;
 #endif
 
 // Third page
-#ifdef PIN_PA14
+#if defined(PIN_PA14) && !defined(IGNORE_PIN_PA14)
 extern const mcu_pin_obj_t pin_PA14;
 #endif
-#ifdef PIN_PA15
+#if defined(PIN_PA15) && !defined(IGNORE_PIN_PA15)
 extern const mcu_pin_obj_t pin_PA15;
 #endif
-#ifdef PIN_PA16
+#if defined(PIN_PA16) && !defined(IGNORE_PIN_PA16)
 extern const mcu_pin_obj_t pin_PA16;
 #endif
-#ifdef PIN_PA17
+#if defined(PIN_PA17) && !defined(IGNORE_PIN_PA17)
 extern const mcu_pin_obj_t pin_PA17;
 #endif
-#ifdef PIN_PA18
+#if defined(PIN_PA18) && !defined(IGNORE_PIN_PA18)
 extern const mcu_pin_obj_t pin_PA18;
 #endif
-#ifdef PIN_PA19
+#if defined(PIN_PA19) && !defined(IGNORE_PIN_PA19)
 extern const mcu_pin_obj_t pin_PA19;
 #endif
-#ifdef PIN_PC16
+#if defined(PIN_PC16) && !defined(IGNORE_PIN_PC16)
 extern const mcu_pin_obj_t pin_PC16;
 #endif
-#ifdef PIN_PC17
+#if defined(PIN_PC17) && !defined(IGNORE_PIN_PC17)
 extern const mcu_pin_obj_t pin_PC17;
 #endif
-#ifdef PIN_PC18
+#if defined(PIN_PC18) && !defined(IGNORE_PIN_PC18)
 extern const mcu_pin_obj_t pin_PC18;
 #endif
-#ifdef PIN_PC19
+#if defined(PIN_PC19) && !defined(IGNORE_PIN_PC19)
 extern const mcu_pin_obj_t pin_PC19;
 #endif
-#ifdef PIN_PC20
+#if defined(PIN_PC20) && !defined(IGNORE_PIN_PC20)
 extern const mcu_pin_obj_t pin_PC20;
 #endif
-#ifdef PIN_PC21
+#if defined(PIN_PC21) && !defined(IGNORE_PIN_PC21)
 extern const mcu_pin_obj_t pin_PC21;
 #endif
-#ifdef PIN_PC22
+#if defined(PIN_PC22) && !defined(IGNORE_PIN_PC22)
 extern const mcu_pin_obj_t pin_PC22;
 #endif
-#ifdef PIN_PC23
+#if defined(PIN_PC23) && !defined(IGNORE_PIN_PC23)
 extern const mcu_pin_obj_t pin_PC23;
 #endif
-#ifdef PIN_PD20
+#if defined(PIN_PD20) && !defined(IGNORE_PIN_PD20)
 extern const mcu_pin_obj_t pin_PD20;
 #endif
-#ifdef PIN_PD21
+#if defined(PIN_PD21) && !defined(IGNORE_PIN_PD21)
 extern const mcu_pin_obj_t pin_PD21;
 #endif
-#ifdef PIN_PB16
+#if defined(PIN_PB16) && !defined(IGNORE_PIN_PB16)
 extern const mcu_pin_obj_t pin_PB16;
 #endif
-#ifdef PIN_PB17
+#if defined(PIN_PB17) && !defined(IGNORE_PIN_PB17)
 extern const mcu_pin_obj_t pin_PB17;
 #endif
-#ifdef PIN_PB18
+#if defined(PIN_PB18) && !defined(IGNORE_PIN_PB18)
 extern const mcu_pin_obj_t pin_PB18;
 #endif
-#ifdef PIN_PB19
+#if defined(PIN_PB19) && !defined(IGNORE_PIN_PB19)
 extern const mcu_pin_obj_t pin_PB19;
 #endif
-#ifdef PIN_PB20
+#if defined(PIN_PB20) && !defined(IGNORE_PIN_PB20)
 extern const mcu_pin_obj_t pin_PB20;
 #endif
-#ifdef PIN_PB21
+#if defined(PIN_PB21) && !defined(IGNORE_PIN_PB21)
 extern const mcu_pin_obj_t pin_PB21;
 #endif
-#ifdef PIN_PA20
+#if defined(PIN_PA20) && !defined(IGNORE_PIN_PA20)
 extern const mcu_pin_obj_t pin_PA20;
 #endif
-#ifdef PIN_PA21
+#if defined(PIN_PA21) && !defined(IGNORE_PIN_PA21)
 extern const mcu_pin_obj_t pin_PA21;
 #endif
-#ifdef PIN_PA22
+#if defined(PIN_PA22) && !defined(IGNORE_PIN_PA22)
 extern const mcu_pin_obj_t pin_PA22;
 #endif
-#ifdef PIN_PA23
+#if defined(PIN_PA23) && !defined(IGNORE_PIN_PA23)
 extern const mcu_pin_obj_t pin_PA23;
 #endif
-#ifdef PIN_PA24
+#if defined(PIN_PA24) && !defined(IGNORE_PIN_PA24)
 extern const mcu_pin_obj_t pin_PA24;
 #endif
-#ifdef PIN_PA25
+#if defined(PIN_PA25) && !defined(IGNORE_PIN_PA25)
 extern const mcu_pin_obj_t pin_PA25;
 #endif
 
 // Fourth page
-#ifdef PIN_PB22
+#if defined(PIN_PB22) && !defined(IGNORE_PIN_PB22)
 extern const mcu_pin_obj_t pin_PB22;
 #endif
-#ifdef PIN_PB23
+#if defined(PIN_PB23) && !defined(IGNORE_PIN_PB23)
 extern const mcu_pin_obj_t pin_PB23;
 #endif
-#ifdef PIN_PB24
+#if defined(PIN_PB24) && !defined(IGNORE_PIN_PB24)
 extern const mcu_pin_obj_t pin_PB24;
 #endif
-#ifdef PIN_PB25
+#if defined(PIN_PB25) && !defined(IGNORE_PIN_PB25)
 extern const mcu_pin_obj_t pin_PB25;
 #endif
-#ifdef PIN_PB26
+#if defined(PIN_PB26) && !defined(IGNORE_PIN_PB26)
 extern const mcu_pin_obj_t pin_PB26;
 #endif
-#ifdef PIN_PB27
+#if defined(PIN_PB27) && !defined(IGNORE_PIN_PB27)
 extern const mcu_pin_obj_t pin_PB27;
 #endif
-#ifdef PIN_PB28
+#if defined(PIN_PB28) && !defined(IGNORE_PIN_PB28)
 extern const mcu_pin_obj_t pin_PB28;
 #endif
-#ifdef PIN_PB29
+#if defined(PIN_PB29) && !defined(IGNORE_PIN_PB29)
 extern const mcu_pin_obj_t pin_PB29;
 #endif
-#ifdef PIN_PC24
+#if defined(PIN_PC24) && !defined(IGNORE_PIN_PC24)
 extern const mcu_pin_obj_t pin_PC24;
 #endif
-#ifdef PIN_PC25
+#if defined(PIN_PC25) && !defined(IGNORE_PIN_PC25)
 extern const mcu_pin_obj_t pin_PC25;
 #endif
-#ifdef PIN_PC26
+#if defined(PIN_PC26) && !defined(IGNORE_PIN_PC26)
 extern const mcu_pin_obj_t pin_PC26;
 #endif
-#ifdef PIN_PC27
+#if defined(PIN_PC27) && !defined(IGNORE_PIN_PC27)
 extern const mcu_pin_obj_t pin_PC27;
 #endif
-#ifdef PIN_PC28
+#if defined(PIN_PC28) && !defined(IGNORE_PIN_PC28)
 extern const mcu_pin_obj_t pin_PC28;
 #endif
-#ifdef PIN_PA27
+#if defined(PIN_PA27) && !defined(IGNORE_PIN_PA27)
 extern const mcu_pin_obj_t pin_PA27;
 #endif
-#ifdef PIN_PA30
+#if defined(PIN_PA30) && !defined(IGNORE_PIN_PA30)
 extern const mcu_pin_obj_t pin_PA30;
 #endif
-#ifdef PIN_PA31
+#if defined(PIN_PA31) && !defined(IGNORE_PIN_PA31)
 extern const mcu_pin_obj_t pin_PA31;
 #endif
-#ifdef PIN_PB30
+#if defined(PIN_PB30) && !defined(IGNORE_PIN_PB30)
 extern const mcu_pin_obj_t pin_PB30;
 #endif
-#ifdef PIN_PB31
+#if defined(PIN_PB31) && !defined(IGNORE_PIN_PB31)
 extern const mcu_pin_obj_t pin_PB31;
 #endif
-#ifdef PIN_PC30
+#if defined(PIN_PC30) && !defined(IGNORE_PIN_PC30)
 extern const mcu_pin_obj_t pin_PC30;
 #endif
-#ifdef PIN_PC31
+#if defined(PIN_PC31) && !defined(IGNORE_PIN_PC31)
 extern const mcu_pin_obj_t pin_PC31;
 #endif
-#ifdef PIN_PB00
+#if defined(PIN_PB00) && !defined(IGNORE_PIN_PB00)
 extern const mcu_pin_obj_t pin_PB00;
 #endif
-#ifdef PIN_PB01
+#if defined(PIN_PB01) && !defined(IGNORE_PIN_PB01)
 extern const mcu_pin_obj_t pin_PB01;
 #endif
-#ifdef PIN_PB02
+#if defined(PIN_PB02) && !defined(IGNORE_PIN_PB02)
 extern const mcu_pin_obj_t pin_PB02;
 #endif
 #endif  // MICROPY_INCLUDED_ATMEL_SAMD_SAMD51_PINS_H

--- a/samd/samd21/pins.h
+++ b/samd/samd21/pins.h
@@ -40,173 +40,173 @@
 #define NO_PIN PORT_BITS
 
 // Pins in datasheet order.
-#ifdef PIN_PA00
+#if defined(PIN_PA00) && !defined(IGNORE_PIN_PA00)
 extern const mcu_pin_obj_t pin_PA00;
 #endif
-#ifdef PIN_PA01
+#if defined(PIN_PA01) && !defined(IGNORE_PIN_PA01)
 extern const mcu_pin_obj_t pin_PA01;
 #endif
-#ifdef PIN_PA02
+#if defined(PIN_PA02) && !defined(IGNORE_PIN_PA02)
 extern const mcu_pin_obj_t pin_PA02;
 #endif
-#ifdef PIN_PA03
+#if defined(PIN_PA03) && !defined(IGNORE_PIN_PA03)
 extern const mcu_pin_obj_t pin_PA03;
 #endif
-#ifdef PIN_PB04
+#if defined(PIN_PB04) && !defined(IGNORE_PIN_PB04)
 extern const mcu_pin_obj_t pin_PB04;
 #endif
-#ifdef PIN_PB05
+#if defined(PIN_PB05) && !defined(IGNORE_PIN_PB05)
 extern const mcu_pin_obj_t pin_PB05;
 #endif
-#ifdef PIN_PB06
+#if defined(PIN_PB06) && !defined(IGNORE_PIN_PB06)
 extern const mcu_pin_obj_t pin_PB06;
 #endif
-#ifdef PIN_PB07
+#if defined(PIN_PB07) && !defined(IGNORE_PIN_PB07)
 extern const mcu_pin_obj_t pin_PB07;
 #endif
-#ifdef PIN_PB08
+#if defined(PIN_PB08) && !defined(IGNORE_PIN_PB08)
 extern const mcu_pin_obj_t pin_PB08;
 #endif
-#ifdef PIN_PB09
+#if defined(PIN_PB09) && !defined(IGNORE_PIN_PB09)
 extern const mcu_pin_obj_t pin_PB09;
 #endif
-#ifdef PIN_PA04
+#if defined(PIN_PA04) && !defined(IGNORE_PIN_PA04)
 extern const mcu_pin_obj_t pin_PA04;
 #endif
-#ifdef PIN_PA05
+#if defined(PIN_PA05) && !defined(IGNORE_PIN_PA05)
 extern const mcu_pin_obj_t pin_PA05;
 #endif
-#ifdef PIN_PA06
+#if defined(PIN_PA06) && !defined(IGNORE_PIN_PA06)
 extern const mcu_pin_obj_t pin_PA06;
 #endif
-#ifdef PIN_PA07
+#if defined(PIN_PA07) && !defined(IGNORE_PIN_PA07)
 extern const mcu_pin_obj_t pin_PA07;
 #endif
-#ifdef PIN_PA08
+#if defined(PIN_PA08) && !defined(IGNORE_PIN_PA08)
 extern const mcu_pin_obj_t pin_PA08;
 #endif
-#ifdef PIN_PA09
+#if defined(PIN_PA09) && !defined(IGNORE_PIN_PA09)
 extern const mcu_pin_obj_t pin_PA09;
 #endif
-#ifdef PIN_PA10
+#if defined(PIN_PA10) && !defined(IGNORE_PIN_PA10)
 extern const mcu_pin_obj_t pin_PA10;
 #endif
-#ifdef PIN_PA11
+#if defined(PIN_PA11) && !defined(IGNORE_PIN_PA11)
 extern const mcu_pin_obj_t pin_PA11;
 #endif
-#ifdef PIN_PB10
+#if defined(PIN_PB10) && !defined(IGNORE_PIN_PB10)
 extern const mcu_pin_obj_t pin_PB10;
 #endif
-#ifdef PIN_PB11
+#if defined(PIN_PB11) && !defined(IGNORE_PIN_PB11)
 extern const mcu_pin_obj_t pin_PB11;
 #endif
-#ifdef PIN_PB12
+#if defined(PIN_PB12) && !defined(IGNORE_PIN_PB12)
 extern const mcu_pin_obj_t pin_PB12;
 #endif
-#ifdef PIN_PB13
+#if defined(PIN_PB13) && !defined(IGNORE_PIN_PB13)
 extern const mcu_pin_obj_t pin_PB13;
 #endif
-#ifdef PIN_PB14
+#if defined(PIN_PB14) && !defined(IGNORE_PIN_PB14)
 extern const mcu_pin_obj_t pin_PB14;
 #endif
 
 // Second page.
-#ifdef PIN_PB15
+#if defined(PIN_PB15) && !defined(IGNORE_PIN_PB15)
 extern const mcu_pin_obj_t pin_PB15;
 #endif
-#ifdef PIN_PA12
+#if defined(PIN_PA12) && !defined(IGNORE_PIN_PA12)
 extern const mcu_pin_obj_t pin_PA12;
 #endif
-#ifdef PIN_PA13
+#if defined(PIN_PA13) && !defined(IGNORE_PIN_PA13)
 extern const mcu_pin_obj_t pin_PA13;
 #endif
-#ifdef PIN_PA14
+#if defined(PIN_PA14) && !defined(IGNORE_PIN_PA14)
 extern const mcu_pin_obj_t pin_PA14;
 #endif
-#ifdef PIN_PA15
+#if defined(PIN_PA15) && !defined(IGNORE_PIN_PA15)
 extern const mcu_pin_obj_t pin_PA15;
 #endif
-#ifdef PIN_PA16
+#if defined(PIN_PA16) && !defined(IGNORE_PIN_PA16)
 extern const mcu_pin_obj_t pin_PA16;
 #endif
-#ifdef PIN_PA17
+#if defined(PIN_PA17) && !defined(IGNORE_PIN_PA17)
 extern const mcu_pin_obj_t pin_PA17;
 #endif
-#ifdef PIN_PA18
+#if defined(PIN_PA18) && !defined(IGNORE_PIN_PA18)
 extern const mcu_pin_obj_t pin_PA18;
 #endif
-#ifdef PIN_PA19
+#if defined(PIN_PA19) && !defined(IGNORE_PIN_PA19)
 extern const mcu_pin_obj_t pin_PA19;
 #endif
-#ifdef PIN_PB16
+#if defined(PIN_PB16) && !defined(IGNORE_PIN_PB16)
 extern const mcu_pin_obj_t pin_PB16;
 #endif
-#ifdef PIN_PB17
+#if defined(PIN_PB17) && !defined(IGNORE_PIN_PB17)
 extern const mcu_pin_obj_t pin_PB17;
 #endif
-#ifdef PIN_PA20
+#if defined(PIN_PA20) && !defined(IGNORE_PIN_PA20)
 extern const mcu_pin_obj_t pin_PA20;
 #endif
-#ifdef PIN_PA21
+#if defined(PIN_PA21) && !defined(IGNORE_PIN_PA21)
 extern const mcu_pin_obj_t pin_PA21;
 #endif
-#ifdef PIN_PA22
+#if defined(PIN_PA22) && !defined(IGNORE_PIN_PA22)
 extern const mcu_pin_obj_t pin_PA22;
 #endif
-#ifdef PIN_PA23
+#if defined(PIN_PA23) && !defined(IGNORE_PIN_PA23)
 extern const mcu_pin_obj_t pin_PA23;
 #endif
-#ifdef PIN_PA24
+#if defined(PIN_PA24) && !defined(IGNORE_PIN_PA24)
 extern const mcu_pin_obj_t pin_PA24;
 #endif
-#ifdef PIN_PA25
+#if defined(PIN_PA25) && !defined(IGNORE_PIN_PA25)
 extern const mcu_pin_obj_t pin_PA25;
 #endif
-#ifdef PIN_PB22
+#if defined(PIN_PB22) && !defined(IGNORE_PIN_PB22)
 extern const mcu_pin_obj_t pin_PB22;
 #endif
-#ifdef PIN_PB23
+#if defined(PIN_PB23) && !defined(IGNORE_PIN_PB23)
 extern const mcu_pin_obj_t pin_PB23;
 #endif
-#ifdef PIN_PA27
+#if defined(PIN_PA27) && !defined(IGNORE_PIN_PA27)
 extern const mcu_pin_obj_t pin_PA27;
 #endif
-#ifdef PIN_PA28
+#if defined(PIN_PA28) && !defined(IGNORE_PIN_PA28)
 extern const mcu_pin_obj_t pin_PA28;
 #endif
-#ifdef PIN_PA30
+#if defined(PIN_PA30) && !defined(IGNORE_PIN_PA30)
 extern const mcu_pin_obj_t pin_PA30;
 #endif
-#ifdef PIN_PA31
+#if defined(PIN_PA31) && !defined(IGNORE_PIN_PA31)
 extern const mcu_pin_obj_t pin_PA31;
 #endif
-#ifdef PIN_PB30
+#if defined(PIN_PB30) && !defined(IGNORE_PIN_PB30)
 extern const mcu_pin_obj_t pin_PB30;
 #endif
-#ifdef PIN_PB31
+#if defined(PIN_PB31) && !defined(IGNORE_PIN_PB31)
 extern const mcu_pin_obj_t pin_PB31;
 #endif
-#ifdef PIN_PB00
+#if defined(PIN_PB00) && !defined(IGNORE_PIN_PB00)
 extern const mcu_pin_obj_t pin_PB00;
 #endif
-#ifdef PIN_PB01
+#if defined(PIN_PB01) && !defined(IGNORE_PIN_PB01)
 extern const mcu_pin_obj_t pin_PB01;
 #endif
-#ifdef PIN_PB02
+#if defined(PIN_PB02) && !defined(IGNORE_PIN_PB02)
 extern const mcu_pin_obj_t pin_PB02;
 #endif
-#ifdef PIN_PB03
+#if defined(PIN_PB03) && !defined(IGNORE_PIN_PB03)
 extern const mcu_pin_obj_t pin_PB03;
 #endif
 
 // For SAMR
-#ifdef PIN_PC16
+#if defined(PIN_PC16) && !defined(IGNORE_PIN_PC16)
 extern const mcu_pin_obj_t pin_PC16;
 #endif
-#ifdef PIN_PC18
+#if defined(PIN_PC18) && !defined(IGNORE_PIN_PC18)
 extern const mcu_pin_obj_t pin_PC18;
 #endif
-#ifdef PIN_PC19
+#if defined(PIN_PC19) && !defined(IGNORE_PIN_PC19)
 extern const mcu_pin_obj_t pin_PC19;
 #endif
 


### PR DESCRIPTION
This pushes certain errors into being compile-time errors, instead of link-time errors.

Interestingly, sometimes the LTO linker could infer that the first comparison in
```
if (MICROPY_HW_NEOPIXEL == &pin_PA30 && DSU->STATUSB.bit.DBGPRES == 1) {
```
was always false without requiring linkage for `pin_PA30` to exist.  However, it's preferable not to rely on this.

This was discovered because in -flto=## mode (parallel LTO mode) the linker no longer did make this inference, so pin_PA30 beame an undefined symbol.

Before CircuitPython can be updated to use this ref of samd-peripherals, all the errors of this type must be fixed.