### PR TITLE
Provide access to DMA write-back descriptors

### DIFF
--- a/samd/dma.c
+++ b/samd/dma.c
@@ -257,3 +257,7 @@ int32_t qspi_dma_read(uint32_t address, uint8_t* buffer, uint32_t length) {
 DmacDescriptor* dma_descriptor(uint8_t channel_number) {
     return &dma_descriptors[channel_number];
 }
+
+DmacDescriptor* dma_write_back_descriptor(uint8_t channel_number) {
+    return &write_back_descriptors[channel_number];
+}

--- a/samd/dma.h
+++ b/samd/dma.h
@@ -62,5 +62,6 @@ bool dma_channel_free(uint8_t channel_number);
 bool dma_channel_enabled(uint8_t channel_number);
 uint8_t dma_transfer_status(uint8_t channel_number);
 DmacDescriptor* dma_descriptor(uint8_t channel_number);
+DmacDescriptor* dma_write_back_descriptor(uint8_t channel_number);
 
 #endif  // MICROPY_INCLUDED_ATMEL_SAMD_PERIPHERALS_DMA_H


### PR DESCRIPTION
I'm working on SAMD audio, and I need access to the DMA write-back descriptors in order to know reliably which descriptor has finished when the ISR routine is called.