### PR TITLE
Add memory fences when disabling cache

### DIFF
--- a/samd/sam_d5x_e5x/cache.c
+++ b/samd/sam_d5x_e5x/cache.c
@@ -28,9 +28,18 @@
 
 // Turn off cache and invalidate all data in it.
 void samd_peripherals_disable_and_clear_cache(void) {
+    // Memory fence for hardware and compiler reasons. If this routine is inlined, the compiler
+    // needs to know that everything written out be stored before this is called.
+    // -O2 optimization showed this was necessary.
+    __sync_synchronize();
+
     CMCC->CTRL.bit.CEN = 0;
     while (CMCC->SR.bit.CSTS) {}
     CMCC->MAINT0.bit.INVALL = 1;
+
+    // Memory fence for hardware and compiler reasons. Testing showed this second one is also
+    // necessary when compiled with -O2.
+    __sync_synchronize();
 }
 
 // Enable cache


### PR DESCRIPTION
This helps to address https://github.com/adafruit/circuitpython/issues/7279. When compiling with `-O2` optimization, the cache enabling and disabling routines were inlined, apparently causing gcc to make incorrect assumptions. It may also be the case that hardware memory fences were necessary anyway.

`__sync_synchronize()` is `__DMB()` as a `volatile asm` on Cortex-M4, so the memory fence happens in hardware, and gcc also takes notice.

After this is approved and merged, I'll submit a PR to `adafruit/circuitpython`.