### PR TITLE
Remove unnecessary reference to CircuitPython binding

### DIFF
--- a/samd/clocks.c
+++ b/samd/clocks.c
@@ -28,8 +28,6 @@
 
 #include "hpl_gclk_config.h"
 
-#include "shared-bindings/microcontroller/__init__.h"
-
 #include "py/runtime.h"
 
 // TODO(tannewt): Should we have a way of sharing GCLKs based on their speed? Divisor doesn't


### PR DESCRIPTION
The include to `shared-bindings/microcontroller/__init__.h` appears to be unused but makes it difficult to build without CircuitPython.

To be certain, I removed the include and tested building the CircuitPython atmel-samd boards `feather_m4_express` and `trinket_m0` - there were no errors.