### PR TITLE
samx5x: support external clock sources

### DIFF
--- a/samd/clocks.h
+++ b/samd/clocks.h
@@ -56,7 +56,33 @@ void disconnect_gclk_from_peripheral(uint8_t gclk, uint8_t peripheral);
 void enable_clock_generator(uint8_t gclk, uint32_t source, uint16_t divisor);
 void disable_clock_generator(uint8_t gclk);
 
-void clock_init(bool has_crystal, uint32_t dfll48m_fine_calibration);
+/**
+ * @brief Called during port_init to setup system clocks.
+ *
+ * @param has_rtc_crystal Indicates that the board has a crystal for the real-time
+ * clock (RTC). If true, uses the microcontroller's XOSC32k as the RTC's clock source.
+ * For an individual board, this value is configured from BOARD_HAS_CRYSTAL in
+ * mpconfigboard.h.
+ *
+ * @param xosc_freq The frequency of a connected external oscillator, or 0 if no
+ * external oscillator is connected. Non-zero values should be the frequency
+ * in Hertz (Hz) of an external oscillator connected to an XIN pin on this
+ * microcontroller. This is currently only implemented for SAMx5x chips.
+ * For an individual board, this value is configured from BOARD_XOSC_FREQ_HZ
+ * in mpconfigboard.h.
+ *
+ * @param xosc_is_crystal Set to true if the external oscillator (XOSC) described by
+ * `xosc_freq` is a crystal oscillator, or false if it is not. If there is no XOSC,
+ * then `xosc_freq` should be set to 0, in which case this parameter is ignored.
+ * This is currently only implemented for SAMx5x chips.
+ * For an individual board, this value is configured from BOARD_XOSC_IS_CRYSTAL
+ * in mpconfigboard.h.
+ *
+ * @param dfll48m_fine_calibration The fine calibration value for the DFLL48M.
+ * Currently only implemented for SAMD21 chips, and only used if `has_rtc_crystal`
+ * is false.
+ */
+void clock_init(bool has_rtc_crystal, uint32_t xosc_freq, bool xosc_is_crystal, uint32_t dfll48m_fine_calibration);
 void init_dynamic_clocks(void);
 
 bool clock_get_enabled(uint8_t type, uint8_t index);

--- a/samd/samd21/clocks.c
+++ b/samd/samd21/clocks.c
@@ -142,16 +142,19 @@ static void init_clock_source_dfll48m_usb(uint32_t fine_calibration) {
     while (GCLK->STATUS.bit.SYNCBUSY) {}
 }
 
-void clock_init(bool has_crystal, uint32_t dfll48m_fine_calibration)
+void clock_init(bool has_rtc_crystal, uint32_t xosc_freq, bool xosc_is_crystal, uint32_t dfll48m_fine_calibration)
 {
+    // TODO: support using the external oscillator as the system clock source
+    // like the sam_d5x_e5x version of this function.
+
     init_clock_source_osc8m();
-    if (has_crystal) {
+    if (has_rtc_crystal) {
         init_clock_source_xosc32k();
     } else {
         init_clock_source_osc32k();
     }
 
-    if (has_crystal) {
+    if (has_rtc_crystal) {
         enable_clock_generator(3, GCLK_GENCTRL_SRC_XOSC32K_Val, 1);
         connect_gclk_to_peripheral(3, GCLK_CLKCTRL_ID_DFLL48_Val);
         init_clock_source_dfll48m_xosc();
@@ -160,7 +163,7 @@ void clock_init(bool has_crystal, uint32_t dfll48m_fine_calibration)
     }
 
     enable_clock_generator(0, GCLK_GENCTRL_SRC_DFLL48M_Val, 1);
-    if (has_crystal) {
+    if (has_rtc_crystal) {
         enable_clock_generator(2, GCLK_GENCTRL_SRC_XOSC32K_Val, 1);
     } else {
         enable_clock_generator(2, GCLK_GENCTRL_SRC_OSC32K_Val, 1);


### PR DESCRIPTION
This adds two arguments to clock_init, to specify a frequency for XOSC0, and if it is a crystal or not. If `xosc_freq` is non-zero, DPLL0 will use XOSC0 as its REFCLK on SAM_D5x_E5x series chips. This PR doesn't implement external clock source support for SAMD21 chips, so for those chips the new arguments have no effect. This implementation also is limited to XOSC0 frequencies that are integer factors 120 MHz — I figured that was preferable to including a divider calculation algorithm in here, but I can change that if desired.

I also didn't know if GCLK5 was used anywhere else besides for the system clock, so I didn't make bringing it up conditional on the presence of an external clock input, but I can also change that if need be.

For adafruit/circuitpython#6161.