### PR TITLE
Fix SPI dma problems; other cleanups

### DIFF
--- a/samd/dma.h
+++ b/samd/dma.h
@@ -36,9 +36,25 @@
 // vm) because the general_dma resource will be shared between the REPL and SPI
 // flash. Both uses must block each other in order to prevent conflict.
 #define AUDIO_DMA_CHANNEL_COUNT 4
-#define DMA_CHANNEL_COUNT 32
 
-uint8_t dma_allocate_channel(bool audio_channel);
+#ifdef SAMD21
+#define DMA_CHANNEL_COUNT 12
+#endif
+
+#ifdef SAM_D5X_E5X
+#define DMA_CHANNEL_COUNT 32
+#endif
+
+// Returned when a channel can't be allocated.
+#define NO_DMA_CHANNEL 0xff
+
+// Failure values
+#define DMA_FAILURE_NO_CHANNEL_AVAILABLE (-1)
+#define DMA_FAILURE_INCOMPLETE (-2)
+#define DMA_FAILURE_ALIGNMENT (-3)
+
+uint8_t dma_allocate_audio_channel(void);
+uint8_t dma_allocate_non_audio_channel(void);
 void dma_free_channel(uint8_t channel);
 
 void init_shared_dma(void);
@@ -64,14 +80,11 @@ typedef struct {
     bool tx_active;
     bool sercom;
     int8_t failure;
-} dma_descr_t;
+} dma_transfer_t;
 
-dma_descr_t shared_dma_transfer_start(void* peripheral,
-                                   const uint8_t* buffer_out, volatile uint32_t* dest,
-                                   volatile uint32_t* src, uint8_t* buffer_in,
-                                   uint32_t length, uint8_t tx);
-bool shared_dma_transfer_finished(dma_descr_t descr);
-int shared_dma_transfer_close(dma_descr_t descr);
+void shared_dma_transfer_start(dma_transfer_t* transfer, void* peripheral, const uint8_t* buffer_out, volatile uint32_t* dest, volatile uint32_t* src, uint8_t* buffer_in,  uint32_t length, uint8_t tx);
+bool shared_dma_transfer_finished(dma_transfer_t* transfer);
+int shared_dma_transfer_close(dma_transfer_t* transfer);
 
 void dma_configure(uint8_t channel_number, uint8_t trigsrc, bool output_event);
 void dma_enable_channel(uint8_t channel_number);

--- a/samd/samd21/dma.c
+++ b/samd/samd21/dma.c
@@ -58,7 +58,6 @@ void dma_configure(uint8_t channel_number, uint8_t trigsrc, bool output_event) {
 
 void dma_enable_channel(uint8_t channel_number) {
     common_hal_mcu_disable_interrupts();
-    /** Select the DMA channel and clear software trigger */
     DMAC->CHID.reg = DMAC_CHID_ID(channel_number);
     // Clear any previous interrupts.
     DMAC->CHINTFLAG.reg = DMAC_CHINTFLAG_MASK;
@@ -68,7 +67,6 @@ void dma_enable_channel(uint8_t channel_number) {
 
 void dma_disable_channel(uint8_t channel_number) {
     common_hal_mcu_disable_interrupts();
-    /** Select the DMA channel and clear software trigger */
     DMAC->CHID.reg = DMAC_CHID_ID(channel_number);
     DMAC->CHCTRLA.bit.ENABLE = false;
     common_hal_mcu_enable_interrupts();
@@ -76,7 +74,6 @@ void dma_disable_channel(uint8_t channel_number) {
 
 void dma_suspend_channel(uint8_t channel_number) {
     common_hal_mcu_disable_interrupts();
-    /** Select the DMA channel and clear software trigger */
     DMAC->CHID.reg = DMAC_CHID_ID(channel_number);
     DMAC->CHCTRLB.bit.CMD = DMAC_CHCTRLB_CMD_SUSPEND_Val;
     common_hal_mcu_enable_interrupts();
@@ -84,7 +81,6 @@ void dma_suspend_channel(uint8_t channel_number) {
 
 void dma_resume_channel(uint8_t channel_number) {
     common_hal_mcu_disable_interrupts();
-    /** Select the DMA channel and clear software trigger */
     DMAC->CHID.reg = DMAC_CHID_ID(channel_number);
     DMAC->CHCTRLB.bit.CMD = DMAC_CHCTRLB_CMD_RESUME_Val;
     DMAC->CHINTFLAG.reg = DMAC_CHINTFLAG_SUSP;
@@ -93,7 +89,6 @@ void dma_resume_channel(uint8_t channel_number) {
 
 bool dma_channel_enabled(uint8_t channel_number) {
     common_hal_mcu_disable_interrupts();
-    /** Select the DMA channel and clear software trigger */
     DMAC->CHID.reg = DMAC_CHID_ID(channel_number);
     bool enabled = DMAC->CHCTRLA.bit.ENABLE;
     common_hal_mcu_enable_interrupts();
@@ -102,7 +97,6 @@ bool dma_channel_enabled(uint8_t channel_number) {
 
 uint8_t dma_transfer_status(uint8_t channel_number) {
     common_hal_mcu_disable_interrupts();
-    /** Select the DMA channel and clear software trigger */
     DMAC->CHID.reg = DMAC_CHID_ID(channel_number);
     uint8_t status = DMAC->CHINTFLAG.reg;
     common_hal_mcu_enable_interrupts();


### PR DESCRIPTION
Helping to fix https://github.com/adafruit/circuitpython/issues/10663, plus some other changes. Part of PR https://github.com/adafruit/circuitpython/pull/10668

- `shared_dma_transfer_*` routines were passing the `dma_descr_t` struct by value, which caused the caller not to see changes made by the callee,. In particular `.progress`struct member changes were lost. Changed to pass by pointer.
- Change name of that struct from `dma_descr_t` to `dma_transfer_t` to avoid confusion with hardware DMA descriptors also used in that code.
- Define and use `NO_DMA_CHANNEL` instead of `AUDIO_DMA_CHANNEL_COUNT` and `DMA_CHANNEL_COUNT` to indicate an invalid channel number.
- `dma_allocate_channel(bool audio_channel)` replaced by `dma_allocate_audio_channel(void)` and `dma_allocate_non_audio_channel(void)` to not pass control requests as arg and to clarify.
- Remove duplicated incorrect copy-pasta comments in ` samd/samd21/dma.c`.
- `dma.h`: SAMD21 and SAMx5x have different numbers of DMA channels, so define `DMA_CHANNEL_COUNT` separately for each chip family.

Taggin @Randall-Scharpf for interest.

