### PR TITLE
remove incorrect assert

### DIFF
--- a/samd/dma.c
+++ b/samd/dma.c
@@ -76,7 +76,7 @@ void dma_free_channel(uint8_t channel) {
     if (channel == NO_DMA_CHANNEL) {
         return;
     }
-    assert(dma_allocated[channel]);
+    // Might or might not be already allocated.
     dma_disable_channel(channel);
     dma_allocated[channel] = false;
 }


### PR DESCRIPTION
`dma_free_channel()` can be called when the channel might already be free, during some resetting operations. This `assert` does not have to be true.

Discovered while doing some debugging on a debug build in gdb on something unrelated. I hit the assert.