### PR TITLE
busio.SPI: treat requested baudrate as a ceiling

### DIFF
--- a/samd/sercom.c
+++ b/samd/sercom.c
@@ -32,9 +32,15 @@
 
 
 // Convert frequency to clock-speed-dependent value. Return 255 if > 255.
+// The requested baudrate is treated as a ceiling: the resulting frequency is
+// the requested value or the nearest lower available value, never higher.
+// Since f_baud = f_ref / (2 * (BAUD + 1)), the smallest BAUD that keeps
+// f_baud <= baudrate is ceil(f_ref / (2 * baudrate)) - 1. When the requested
+// baudrate exceeds f_ref / 2, BAUD clamps to 0 (the hardware maximum).
 uint8_t samd_peripherals_spi_baudrate_to_baud_reg_value(const uint32_t baudrate) {
-    uint32_t baud_reg_value = (uint32_t) (((float) PROTOTYPE_SERCOM_SPI_M_SYNC_CLOCK_FREQUENCY /
-                                           (2 * baudrate)) - 0.5f);
+    const uint32_t divisor = 2 * baudrate;
+    uint32_t baud_reg_value =
+        (PROTOTYPE_SERCOM_SPI_M_SYNC_CLOCK_FREQUENCY + divisor - 1) / divisor - 1;
     return (uint8_t) (baud_reg_value > 255 ? 255 : baud_reg_value);
 }
 


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code) :

`samd_peripherals_spi_baudrate_to_baud_reg_value()` rounded to the *nearest* available baudrate, which could set the SPI clock **higher** than the value the user requested.

This changes it to treat the requested baudrate as a ceiling: the resulting frequency is the requested value or the nearest lower available value, never higher.

Since `f_baud = f_ref / (2 * (BAUD + 1))`, the smallest `BAUD` that keeps `f_baud <= baudrate` is `ceil(f_ref / (2 * baudrate)) - 1`, computed with integer math as `(f_ref + 2*baudrate - 1) / (2*baudrate) - 1`. When the requested baudrate exceeds `f_ref / 2`, `BAUD` clamps to 0 (the hardware maximum), matching the previous behavior at the top end.

This is the samd half of a cross-port effort to make SPI baudrate a ceiling rather than nearest-rounding on CircuitPython.

